### PR TITLE
Kern-Qualität R1: Cross-Theme-Kohärenz + Swipe-Schärfung

### DIFF
--- a/index.html
+++ b/index.html
@@ -410,7 +410,7 @@ input[type=checkbox]:disabled+.toggle-visual{opacity:0.38;cursor:not-allowed}
     <button class="btn btn-primary" id="btn-start"></button>
     <button class="btn btn-ghost" id="btn-library" type="button"></button>
   </div>
-  <div class="app-version">v2026-06-21.3</div>
+  <div class="app-version">v2026-06-21.4</div>
 </section>
 <section id="screen-intro" class="screen">
   <div class="intro-wrap">

--- a/src/core/conflicts.ts
+++ b/src/core/conflicts.ts
@@ -1,0 +1,64 @@
+/* =====================================================
+   Konflikt-Guard: vermeidet harte Identitaets-Widersprueche ZWISCHEN den
+   4 Themes (innerhalb eines Themes ist Kohaerenz bereits strukturell garantiert).
+   Bewusst kuratiert + hochpraezise (Substring-Match auf Tag-Texten), damit
+   Falsch-Positive wie metaphorisch "blind durch Ehre" nicht ausgeloest werden.
+   Hinweis: Die "mundane" Gegenseite (b) ist in den Daten oft nicht explizit
+   getaggt — der eigentliche Schutz vor Identitaets-Dissonanz ist die Hook-
+   Kohaesion (scoring.ts). Dieser Guard faengt die expliziten Faelle.
+===================================================== */
+export interface ConflictDomain { name: string; a: string[]; b: string[]; }
+
+export const CONFLICT_DOMAINS: ConflictDomain[] = [
+  {
+    name: 'Wesensnatur', // Mensch <-> Nicht-Mensch/monstroes
+    a: ['kein mensch', 'nicht menschlich', 'monströs', 'monstroes', 'ungeheuer', 'bestie', 'kreatur', 'unmensch', 'wechselbalg', 'unheimliches wesen', 'nicht von dieser welt'],
+    b: ['gewöhnlicher mensch', 'gewoehnlicher mensch', 'ganz normaler mensch', 'einfacher mensch', 'bloß ein mensch', 'bloss ein mensch', 'sterblich und gewöhnlich'],
+  },
+  {
+    name: 'Magie', // uebernatuerlich <-> ausdruecklich mundan/magielos
+    a: ['magisch', 'zauber', 'verzaubert', 'übernatürlich', 'uebernatuerlich', 'arkan', 'hexerei', 'beschwört', 'beschwoert'],
+    b: ['magielos', 'ohne magie', 'keine magie', 'magieblind', 'der magie abhold', 'nüchterne welt', 'nuechterne welt'],
+  },
+  {
+    name: 'Sprache', // Stimme/Rede <-> Stummheit
+    a: ['durchdringende stimme', 'redegewandt', 'wortgewaltig', 'beredt', 'mächtige wort', 'maechtige wort'],
+    b: ['stumm', 'sprachlos', 'verstummt', 'kann nicht reden', 'kann nicht sprechen', 'wortlos'],
+  },
+  {
+    name: 'Bindung', // ortsgebunden <-> rastlos/fahrend
+    a: ['kann nicht fortgehen', 'ortsgebunden', 'an einen ort gebunden', 'tief verwurzelt'],
+    b: ['rastlos', 'ewig unterwegs', 'nirgends zuhause', 'immer auf der straße', 'immer auf der strasse'],
+  },
+];
+
+function themeTexts(t: any): string {
+  var parts: string[] = [];
+  if (t.titleTag && t.titleTag.text) parts.push(t.titleTag.text);
+  (t.powerTags || []).forEach(function (p: any) { if (p && p.text) parts.push(p.text); });
+  if (t.weaknessTag && t.weaknessTag.text) parts.push(t.weaknessTag.text);
+  return parts.join(' · ').toLowerCase();
+}
+function any(hay: string, needles: string[]): boolean {
+  for (var i = 0; i < needles.length; i++) { if (hay.indexOf(needles[i]) !== -1) return true; }
+  return false;
+}
+function pairConflicts(xa: string, xb: string): boolean {
+  for (var d = 0; d < CONFLICT_DOMAINS.length; d++) {
+    var dom = CONFLICT_DOMAINS[d];
+    if ((any(xa, dom.a) && any(xb, dom.b)) || (any(xa, dom.b) && any(xb, dom.a))) return true;
+  }
+  return false;
+}
+
+/** Index des spaeteren Themes, das mit einem frueheren kollidiert; sonst -1. */
+export function findConflictIndex(themes: any[]): number {
+  var texts = themes.map(themeTexts);
+  for (var j = 1; j < themes.length; j++) {
+    for (var i = 0; i < j; i++) {
+      if (pairConflicts(texts[i], texts[j])) return j;
+    }
+  }
+  return -1;
+}
+export function hasConflict(themes: any[]): boolean { return findConflictIndex(themes) !== -1; }

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -20,6 +20,11 @@ export const CFG = Object.freeze({
   MAX_PROPOSALS: 4, MAX_ELEMENT_ALTS: 3, HAPTIC_MS: 6, AUDIO_VOLUME: 0.4,
   MUTED_KEY: 'mistheld:muted', SETTINGS_KEY: 'mistheld:settings', EXPANDED_PREFERENCE: 0.7,
   MIN_SWIPES_FOR_SKIP: 10,
+  // Kern-Qualität R1: Charakter-Profil + Cross-Theme-Kohäsion (Swipe-Schärfung).
+  PROFILE_SIZE: 4,        // Top-N positive Hooks bilden das Charakter-Profil
+  PROFILE_WEIGHT: 4,      // Gewicht der Profil-Überlappung bei der Auswahl (höher = entschiedener)
+  COHESION_WEIGHT: 3,     // Gewicht der Überlappung mit bereits gewählten Themes (= ein Charakter)
+  MAX_COHESION_RETRIES: 6, // Re-Roll-Versuche des Konflikt-Guards (Terminierung garantiert)
 });
 
 // #44: Default-Stufe pro Theme Type laut Quellbuch

--- a/src/core/generation.ts
+++ b/src/core/generation.ts
@@ -12,9 +12,11 @@ import { STORY_FRAGMENTS, STORY_CLOSINGS } from '../data/storyFragments';
 import { loadSettings, effectiveLevel, getEnabledThemeTypes } from './settings';
 import { DEFAULT_THEME_TIER, CFG, TIER_DEVIATION_TAGS } from './constants';
 import {
-  pickTitleWithBias, pickWithSwipeBias, pickQuestWithBias, pickBestFrom, pickRandomFrom,
+  pickTitleWithBias, pickTitleCohesive, characterProfile,
+  pickWithSwipeBias, pickQuestWithBias, pickBestFrom, pickRandomFrom,
   tagHooks, weightedPickIndex,
 } from './scoring';
+import { findConflictIndex } from './conflicts';
 import { capitalizeFirst } from '../util/text';
 
 export function generateTierDeviationTag(level: string): any {
@@ -22,9 +24,12 @@ export function generateTierDeviationTag(level: string): any {
   return { text: pool[Math.floor(Math.random() * pool.length)], expanded: false };
 }
 
-export function generateTheme(name: string, settings: any): any {
+export function generateTheme(name: string, settings: any, ctx?: any): any {
   var tb = (THEMEBOOKS as any)[name];
-  var entry = pickTitleWithBias(tb.titles);              // Titel-Buendel (Anker)
+  // Mit Kohaesions-Kontext: Titel entlang Profil + bereits gewaehlter Themes ziehen.
+  var entry = ctx
+    ? pickTitleCohesive(tb.titles, ctx.profile, ctx.chosenHooks)
+    : pickTitleWithBias(tb.titles);                      // Titel-Buendel (Anker)
   var titleTag = { text: entry.text, expanded: false, hooks: tagHooks(entry) };
   var powerTags = pickWithSwipeBias(entry.powerTags, 2);  // aus DEM Buendel
   var weaknessTag = pickWithSwipeBias(entry.weaknessTags, 1)[0];
@@ -62,7 +67,41 @@ export function generateProposal(mode?: string, base?: any): any {
     used.push(pick);
     tbs.push(pick);
   }
-  return { mode: mode, themes: tbs.map(function (tb) { return generateTheme(tb, s); }) };
+
+  // Cross-Theme-Kohaesion: Profil aus den Swipes; chosenHooks akkumuliert die
+  // Hooks bereits gewaehlter Themes, sodass die 4 entlang eines Fadens ziehen.
+  var profile = characterProfile();
+  var chosenHooks: Record<string, number> = {};
+  function themeHooks(t: any): string[] {
+    return (tagHooks(t.titleTag) || [])
+      .concat(tagHooks(t.powerTags[0]) || [], tagHooks(t.powerTags[1]) || []);
+  }
+  function addHooks(map: Record<string, number>, t: any): void {
+    themeHooks(t).forEach(function (h) { map[h] = (map[h] || 0) + 1; });
+  }
+  var themes: any[] = [];
+  for (var k = 0; k < tbs.length; k++) {
+    var th = generateTheme(tbs[k], s, { profile: profile, chosenHooks: chosenHooks });
+    themes.push(th);
+    addHooks(chosenHooks, th);
+  }
+
+  // Konflikt-Guard: harte Identitaets-Widersprueche zwischen Themes aufloesen.
+  for (var attempt = 0; attempt < CFG.MAX_COHESION_RETRIES; attempt++) {
+    var ci = findConflictIndex(themes);
+    if (ci === -1) break;
+    // Kohaesions-Kontext OHNE das betroffene Theme neu aufbauen.
+    var ch2: Record<string, number> = {};
+    for (var x = 0; x < themes.length; x++) { if (x !== ci) addHooks(ch2, themes[x]); }
+    // Ab der Haelfte der Versuche ein ungenutztes Themebook waehlen, falls der
+    // Buendel-Re-Roll desselben Themebooks den Konflikt nicht aufloest.
+    if (attempt >= 3) {
+      var alt = enabled.filter(function (b) { return tbs.indexOf(b) === -1; });
+      if (alt.length) tbs[ci] = pickRandomFrom(alt);
+    }
+    themes[ci] = generateTheme(tbs[ci], s, { profile: profile, chosenHooks: ch2 });
+  }
+  return { mode: mode, themes: themes };
 }
 
 /* HELD-GENERATOR */

--- a/src/core/scoring.ts
+++ b/src/core/scoring.ts
@@ -55,13 +55,60 @@ export function weightedPickIndex(weights: number[]): number {
   for (var i = 0; i < weights.length; i++) { r -= weights[i]; if (r <= 0) return i; }
   return weights.length - 1;
 }
-// Tag-Auswahl: ohne Hook-Signal exakt wie bisher (Expanded-Preference), sonst hook-gewichtet
+
+/* =====================================================
+   Charakter-Profil: Top-N positive Hooks aus den Swipes, RANGBASIERT gewichtet
+   (Platz 1 am staerksten). Diminishing returns gegen Ja-Inflation: gestreute
+   schwache Hooks verlieren Einfluss -> entschiedener, weniger "Random".
+===================================================== */
+export function characterProfile(): Record<string, number> {
+  var entries = Object.keys(state.hookCounts)
+    .map(function (h) { return [h, state.hookCounts[h]] as [string, number]; })
+    .filter(function (x) { return x[1] > 0; })
+    .sort(function (a, b) { return b[1] - a[1]; })
+    .slice(0, CFG.PROFILE_SIZE);
+  var profile: Record<string, number> = {};
+  var k = entries.length;
+  entries.forEach(function (x, i) { profile[x[0]] = (k - i) / k; }); // 1.0 .. 1/k
+  return profile;
+}
+export function hasProfileSignal(profile: Record<string, number>): boolean { return Object.keys(profile).length > 0; }
+export function profileScore(e: any, profile: Record<string, number>): number {
+  var hs = tagHooks(e), sc = 0;
+  for (var i = 0; i < hs.length; i++) { sc += profile[hs[i]] || 0; }
+  return sc;
+}
+// Einheitliches Auswahl-Gewicht: Profil-Pfad (geschaerft) wenn Signal da, sonst Legacy-hookScore.
+function biasWeight(e: any, profile: Record<string, number>, expandedBonus: boolean): number {
+  var base = hasProfileSignal(profile)
+    ? CFG.PROFILE_WEIGHT * profileScore(e, profile)
+    : 2.5 * hookScore(e);
+  return 1 + base + (expandedBonus && isExpanded(e) ? 0.6 : 0);
+}
+function hasSignalFor(arr: any[], profile: Record<string, number>): boolean {
+  return arr.some(function (e) { return (hasProfileSignal(profile) ? profileScore(e, profile) : hookScore(e)) > 0; });
+}
+
+/* Titel-Buendel mit Cross-Theme-Kohaesion ziehen: Profil-Ueberlappung PLUS Bonus
+   fuer Ueberlappung mit den Hooks bereits gewaehlter Themes (chosenHooks) =>
+   die 4 Themes ziehen entlang eines gemeinsamen Fadens (ein Charakter). */
+export function pickTitleCohesive(titles: any[], profile: Record<string, number>, chosenHooks: Record<string, number>): any {
+  var hasCohesion = Object.keys(chosenHooks).length > 0;
+  if (!hasSignalFor(titles, profile) && !hasCohesion) return titles[Math.floor(Math.random() * titles.length)];
+  var weights = titles.map(function (t) {
+    var hs = tagHooks(t), coh = 0;
+    for (var i = 0; i < hs.length; i++) { coh += chosenHooks[hs[i]] || 0; }
+    return 1 + CFG.PROFILE_WEIGHT * profileScore(t, profile) + CFG.COHESION_WEIGHT * coh;
+  });
+  return titles[weightedPickIndex(weights)];
+}
+// Tag-Auswahl: ohne Signal exakt wie bisher (Expanded-Preference), sonst profil-geschaerft.
 export function pickWithSwipeBias(arr: any[], n: number): any[] {
-  var hasSignal = arr.some(function (e) { return hookScore(e) > 0; });
-  if (!hasSignal) return pickWithExpansionPreference(arr, n);
+  var profile = characterProfile();
+  if (!hasSignalFor(arr, profile)) return pickWithExpansionPreference(arr, n);
   var pool = arr.slice(), out: any[] = [], target = Math.min(n, pool.length);
   while (out.length < target && pool.length > 0) {
-    var weights = pool.map(function (e) { return 1 + 2.5 * hookScore(e) + (isExpanded(e) ? 0.6 : 0); });
+    var weights = pool.map(function (e) { return biasWeight(e, profile, true); });
     var idx = weightedPickIndex(weights);
     var e = pool.splice(idx, 1)[0];
     out.push({ text: tagText(e), expanded: isExpanded(e), hooks: tagHooks(e) });
@@ -70,9 +117,9 @@ export function pickWithSwipeBias(arr: any[], n: number): any[] {
 }
 // Quest-Auswahl analog (Quests sind Objekte {title,description,expanded?,hooks?})
 export function pickQuestWithBias(pool: any[]): any {
-  var hasSignal = pool.some(function (q) { return hookScore(q) > 0; });
-  if (!hasSignal) return pickQuestWithExp(pool);
-  var weights = pool.map(function (q) { return 1 + 2.5 * hookScore(q) + (q.expanded ? 0.6 : 0); });
+  var profile = characterProfile();
+  if (!hasSignalFor(pool, profile)) return pickQuestWithExp(pool);
+  var weights = pool.map(function (q) { return biasWeight(q, profile, !!q.expanded); });
   return pool[weightedPickIndex(weights)];
 }
 // Einzelnes Element hook-gewichtet ziehen
@@ -82,10 +129,11 @@ export function pickOneWithBias(arr: any[]): any {
   var weights = arr.map(function (e) { return 1 + 2.5 * hookScore(e); });
   return arr[weightedPickIndex(weights)];
 }
-// Titel-Buendel hook-gewichtet ziehen (gibt das ganze Buendel zurueck = Anker).
+// Titel-Buendel ziehen (ganzes Buendel = Anker), profil-geschaerft. Ohne Kohaesions-
+// Kontext (z. B. Welcome-Preview, Einzel-Re-Roll). Mit Kontext: pickTitleCohesive.
 export function pickTitleWithBias(titles: any[]): any {
-  var hasSignal = titles.some(function (t) { return hookScore(t) > 0; });
-  if (!hasSignal) return titles[Math.floor(Math.random() * titles.length)];
-  var weights = titles.map(function (t) { return 1 + 2.5 * hookScore(t); });
+  var profile = characterProfile();
+  if (!hasSignalFor(titles, profile)) return titles[Math.floor(Math.random() * titles.length)];
+  var weights = titles.map(function (t) { return biasWeight(t, profile, false); });
   return titles[weightedPickIndex(weights)];
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,8 @@ import { THEMEBOOKS } from './data/themebooks.js';
 import { PHASES } from './data/inspirations.js';
 import { HERO_FIRSTNAMES } from './data/heroPools.js';
 import { generateProposal, generateHero, composeHeroStory } from './core/generation';
+import { characterProfile } from './core/scoring';
+import { hasConflict } from './core/conflicts';
 import { initStrings, show } from './ui/navigation';
 import { initAudio } from './ui/audio';
 import { initWelcomePreview } from './ui/welcomePreview';
@@ -90,4 +92,5 @@ document.addEventListener('keydown', function (e: any) {
 Object.assign(window as any, {
   state, STRINGS, THEMEBOOKS, PHASES, HERO_FIRSTNAMES,
   generateProposal, generateHero, composeHeroStory, show, renderHeldenblatt,
+  characterProfile, hasConflict,
 });

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -242,6 +242,46 @@ test('Bibliothek: gespeicherten Helden auflisten und oeffnen', async ({ page }) 
   await expect(page.locator('.hb-hero-name')).toBeVisible();
 });
 
+// KERN-QUALITÄT R1: Cross-Theme-Kohärenz + Swipe-Schärfung
+test('Kern-Qualität: keine Cross-Theme-Widersprüche (Konflikt-Guard)', async ({ page }) => {
+  await page.goto('/');
+  const bad = await page.evaluate(() => {
+    localStorage.setItem('mistheld:settings', JSON.stringify({ preset: 'custom' }));
+    // Starkes uebernatuerliches Signal -> Themes tendieren zu Magie/Monstrositaet/Unheimlich.
+    state.affinityScores = { Magic: 5, 'Uncanny Being': 4, Monstrosity: 4, Knowledge: 3 };
+    state.hookCounts = { magie: 9, geheimnis: 7, schicksal: 6, macht: 4 };
+    let conflicts = 0;
+    for (let i = 0; i < 150; i++) {
+      const p = generateProposal('initial');
+      if (hasConflict(p.themes)) conflicts++;
+    }
+    return conflicts;
+  });
+  expect(bad).toBe(0);
+});
+
+test('Kern-Qualität: bei klarem Signal tragen (fast) alle Themes die Profil-Hooks (geeinter Charakter)', async ({ page }) => {
+  await page.goto('/');
+  const fraction = await page.evaluate(() => {
+    localStorage.setItem('mistheld:settings', JSON.stringify({ preset: 'custom' }));
+    state.affinityScores = { Magic: 5, Knowledge: 4, 'Uncanny Being': 3, Relic: 3 };
+    state.hookCounts = { magie: 10, geheimnis: 8, wissen: 6 };
+    const targets = ['magie', 'geheimnis', 'wissen'];
+    let hit = 0, tot = 0;
+    for (let i = 0; i < 150; i++) {
+      const p = generateProposal('initial');
+      p.themes.forEach((t) => {
+        tot++;
+        const hs = (t.titleTag.hooks || []).concat(t.powerTags[0].hooks || [], t.powerTags[1].hooks || []);
+        if (hs.some((h) => targets.indexOf(h) !== -1)) hit++;
+      });
+    }
+    return hit / tot;
+  });
+  // Profil-Schärfung + Cross-Theme-Kohäsion: die 4 Themes ziehen entlang des Swipe-Signals.
+  expect(fraction).toBeGreaterThan(0.8);
+});
+
 // #35: PHASEN-BALANCE
 test('#35: Alle 20 Theme-Types haben Phasenkarten-Affinitaet', async ({ page }) => {
   await page.goto('/');


### PR DESCRIPTION
## Kern-Qualität R1 — Cross-Theme-Kohärenz + Swipe-Schärfung (Engine)

Reine Engine-Verbesserung: die 4 Themes wirken jetzt wie **ein** Charakter (statt unabhängig gezogen), und das Swipe-Signal prägt das Ergebnis **entschiedener** (weniger Zufall). **Keine UI-, keine Daten-Änderung.**

### Änderungen
- **`src/core/scoring.ts`** — `characterProfile()` (Top-4 positive Swipe-Hooks, rangbasiert; diminishing returns gegen Ja-Inflation) + `profileScore`. Picker profil-geschärft: Gewicht `1 + PROFILE_WEIGHT·profileScore` statt linear `hookScore`. Neuer `pickTitleCohesive` (Profil + Überlappung mit bereits gewählten Themes).
- **`src/core/generation.ts`** — `generateProposal` führt einen `chosenHooks`-Akkumulator → die Themes ziehen entlang eines gemeinsamen Fadens. Danach **Konflikt-Guard**, der harte Identitäts-Widersprüche zwischen Themes auflöst (Re-Roll des späteren Themes, im Zweifel anderes Themebook, ≤6 Versuche).
- **`src/core/conflicts.ts`** (neu) — 4 kuratierte Domänen: Wesensnatur (Mensch↔Nicht-Mensch/monströs), Magie↔mundan, Sprache↔Stummheit, Bindung↔rastlos + `findConflictIndex`/`hasConflict`.
- **`src/core/constants.ts`** — Tuning (`PROFILE_SIZE`, `PROFILE_WEIGHT`, `COHESION_WEIGHT`, `MAX_COHESION_RETRIES`).

### Verifikation
- `tsc` grün, `vite build` grün, **Playwright 26/26** (2 neue: kein Konfliktpaar in 150 Proposals; bei klarem Signal tragen ~alle 4 Themes die Profil-Hooks).
- Beispiel (Signal Magie/Geheimnis): *Bannerin der Geister · Bewohner des Verborgenen · Wechselgestalt · Kessel der Beschwörung* — alle teilen „geheimnis", kein Widerspruch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
