### PR TITLE
UI R1b: CTA-Layout (Variante B) + echtes Overlay-Zucken-Fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@ body.swipe-active{overflow:hidden;position:fixed;inset:0;width:100%;height:100%;
 @keyframes fadeIn{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:translateY(0)}}
 h1,h2,h3,h4{font-family:var(--serif);font-weight:600;letter-spacing:0.01em;color:var(--ink)}
 h1{font-size:2.4rem;line-height:1.1}h2{font-size:1.7rem;line-height:1.2}h3{font-size:1.25rem;line-height:1.3}
-.mute-btn,.settings-btn{position:fixed;top:max(12px,env(safe-area-inset-top,12px));width:42px;height:42px;border-radius:50%;border:1px solid var(--line);background:rgba(250,243,223,0.85);-webkit-backdrop-filter:blur(6px);backdrop-filter:blur(6px);display:flex;align-items:center;justify-content:center;cursor:pointer;color:var(--ink-soft);z-index:200;transition:transform 0.15s ease,color 0.2s ease;-webkit-tap-highlight-color:transparent;transform:translate3d(0,0,0);will-change:transform}
+.mute-btn,.settings-btn{position:fixed;top:max(12px,env(safe-area-inset-top,12px));width:42px;height:42px;border-radius:50%;border:1px solid var(--line);background:rgba(250,243,223,0.85);-webkit-backdrop-filter:blur(6px);backdrop-filter:blur(6px);display:flex;align-items:center;justify-content:center;cursor:pointer;color:var(--ink-soft);z-index:200;transition:transform 0.15s ease,color 0.2s ease,opacity 0.25s ease,visibility 0.25s ease;-webkit-tap-highlight-color:transparent;transform:translate3d(0,0,0);will-change:transform}
 .mute-btn{right:max(12px,env(safe-area-inset-right,12px))}
 .settings-btn{left:max(12px,env(safe-area-inset-left,12px))}
 .mute-btn:active,.settings-btn:active{transform:translate3d(0,0,0) scale(0.9)}
@@ -50,7 +50,7 @@ h1{font-size:2.4rem;line-height:1.1}h2{font-size:1.7rem;line-height:1.2}h3{font-
 .mute-btn .icon-off{display:none}
 .mute-btn.muted .icon-on{display:none}
 .mute-btn.muted .icon-off{display:block;color:var(--accent)}
-body.overlay-open .mute-btn,body.overlay-open .settings-btn{display:none}
+body.overlay-open .mute-btn,body.overlay-open .settings-btn{opacity:0;visibility:hidden;pointer-events:none}
 /* WELCOME */
 #screen-welcome{padding:0;position:relative;overflow:hidden}
 .welcome-scroll{flex:1;min-height:0;width:100%;overflow-y:auto;-webkit-overflow-scrolling:touch;text-align:center;padding:56px 24px 40px;position:relative;z-index:1}
@@ -67,7 +67,7 @@ body.overlay-open .mute-btn,body.overlay-open .settings-btn{display:none}
 .welcome-title{text-shadow:0 1px 16px rgba(244,234,213,0.7)}
 #screen-swipe{position:relative}
 #screen-swipe>.card-counter,#screen-swipe>.card-stage,#screen-swipe>.swipe-controls{position:relative;z-index:1}
-#btn-start{box-shadow:0 8px 22px rgba(40,30,15,0.4)}
+#btn-start{box-shadow:0 6px 16px rgba(40,30,15,0.22)}
 .app-version{position:absolute;left:max(12px,env(safe-area-inset-left,12px));bottom:max(10px,env(safe-area-inset-bottom,10px));font-family:var(--sans);font-size:0.68rem;letter-spacing:0.04em;color:#f0e6cf;opacity:0.8;text-shadow:0 1px 4px rgba(40,30,15,0.45);z-index:1;user-select:none;pointer-events:none}
 .welcome-mark{font-family:var(--serif);font-style:italic;font-size:1.15rem;color:var(--accent);margin-bottom:8px;letter-spacing:0.12em;text-transform:uppercase}
 .welcome-title{font-size:3.2rem;font-weight:500;font-style:italic;margin:6px 0 0;color:var(--ink);position:relative;display:inline-block}
@@ -81,7 +81,7 @@ body.overlay-open .mute-btn,body.overlay-open .settings-btn{display:none}
 #welcome-preview .hb-quest-title{display:-webkit-box;-webkit-line-clamp:1;-webkit-box-orient:vertical;overflow:hidden}
 #welcome-preview .hb-quest-desc{display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
 .btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;font-family:var(--sans);font-weight:600;font-size:0.95rem;letter-spacing:0.02em;padding:14px 28px;border:none;border-radius:2px;cursor:pointer;transition:all 0.2s ease;min-height:48px;user-select:none}
-#btn-start{align-self:center;padding:17px 46px;font-size:1.18rem;letter-spacing:0.03em;min-width:210px;margin-top:24px}
+#btn-start{align-self:center;width:248px;padding:15px 28px;font-size:1.16rem;letter-spacing:0.03em;margin-top:24px}
 .btn-primary{background:var(--ink);color:var(--bg)}
 .btn-primary:hover{background:var(--accent)}
 .btn-primary:active{transform:scale(0.98)}
@@ -361,7 +361,7 @@ input[type=checkbox]:disabled+.toggle-visual{opacity:0.38;cursor:not-allowed}
 @keyframes spin{to{transform:rotate(360deg)}}
 .loading-text{font-family:var(--serif);font-style:italic;color:#fbf3df;text-shadow:0 1px 6px rgba(0,0,0,0.55)}
 /* BIBLIOTHEK (gespeicherte Helden) */
-#btn-library{align-self:center;margin-top:18px;padding:9px 22px;min-height:38px;font-size:0.82rem;background:transparent;border-color:var(--line-soft);box-shadow:none}
+#btn-library{align-self:center;width:248px;margin-top:12px;padding:12px 28px;min-height:44px;font-size:0.98rem;background:transparent;color:var(--ink-soft);border:1px solid var(--line);box-shadow:none}
 #library-overlay{position:fixed;inset:0;background:rgba(42,36,25,0.52);display:flex;flex-direction:column;justify-content:flex-end;z-index:90;opacity:0;visibility:hidden;transition:opacity 0.25s ease,visibility 0.25s ease}
 #library-overlay.active{opacity:1;visibility:visible}
 #library-sheet{background:var(--paper);border-radius:18px 18px 0 0;max-height:84vh;overflow-y:auto;scrollbar-gutter:stable;-webkit-overflow-scrolling:touch;padding-bottom:max(16px,env(safe-area-inset-bottom,16px));transform:translateY(100%);transition:transform 0.28s cubic-bezier(0.22,1,0.36,1)}
@@ -412,7 +412,7 @@ input[type=checkbox]:disabled+.toggle-visual{opacity:0.38;cursor:not-allowed}
     <button class="btn btn-primary" id="btn-start"></button>
     <button class="btn btn-ghost" id="btn-library" type="button"></button>
   </div>
-  <div class="app-version">v2026-06-23.1</div>
+  <div class="app-version">v2026-06-23.2</div>
 </section>
 <section id="screen-intro" class="screen">
   <div class="intro-wrap">


### PR DESCRIPTION
## Summary

Nachbesserung der ersten UI-Runde (d366588). Zwei Punkte waren verschlechtert/ungeloest.

- **Zucken (echte Ursache, per rAF-Messung belegt):** Der Durchgriff-Schutz schaltete die fixierten Eck-Buttons hart per display:none um, unsynchron zur 250ms-Backdrop-Blende -> Pop in den oberen Ecken bei Oeffnen und Schliessen. Jetzt faden Settings/Mute per opacity + visibility im gleichen Takt wie der Backdrop; pointer-events:none haelt den Durchgriff weiter dicht.
- **CTA (Variante B, vom Nutzer gewaehlt):** Start und Meine Helden gleich breit (248px) gestapelt - Start dunkel gefuellt als klarer Primaer, Meine Helden ruhiger Umriss-Button. Block-Schatten von Start gedaempft.

Nur index.html (CSS). Keine Logikaenderung.

## Test plan

- [x] rAF-Instrumentierung: setOpacity der Eck-Buttons spiegelt Backdrop-Opacity (auf + zu), kein harter display-Flip, headTop konstant
- [x] Playwright 26/26 gruen
- [x] Screenshot Welcome (Mobile): gleich breite Buttons, klare Hierarchie
- [ ] Live-Abnahme im Browser durch Sascha (Optik + Bewegung) -> erst danach mergen

Generated with Claude Code