### PR TITLE
Inspo P1.1: Deck passt zu Einstellungen (kein Ins-Leere) + Teilergebnis

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,8 @@ body.overlay-open .mute-btn,body.overlay-open .settings-btn{display:none}
 .intro-mode.on .intro-mode-tick{color:#f3ecd9}
 /* Erklärtext des gewählten Modus — unter den Kacheln, nicht in ihnen */
 .intro-modedesc{font-size:var(--fs-body);color:var(--ink);line-height:1.45;text-align:center;margin-top:11px;min-height:2.8rem}
+.intro-warning{font-size:var(--fs-label);color:var(--accent);text-align:center;line-height:1.4;margin-top:11px;padding:8px 12px;border:1px solid var(--line);border-radius:8px;background:rgba(139,58,43,0.06)}
+.intro-warning[hidden]{display:none}
 .intro-hint{font-size:var(--fs-label);color:var(--ink-soft);text-align:center;line-height:1.4;margin-top:12px}
 .intro-settings-link{color:var(--accent);text-decoration:underline;text-underline-offset:2px;cursor:pointer}
 .intro-actions{display:flex;gap:10px;align-items:center;justify-content:center}
@@ -413,7 +415,7 @@ input[type=checkbox]:disabled+.toggle-visual{opacity:0.38;cursor:not-allowed}
     <button class="btn btn-primary" id="btn-start"></button>
     <button class="btn btn-ghost" id="btn-library" type="button"></button>
   </div>
-  <div class="app-version">v2026-06-23.5</div>
+  <div class="app-version">v2026-06-24.1</div>
 </section>
 <section id="screen-intro" class="screen">
   <div class="intro-wrap">
@@ -437,6 +439,7 @@ input[type=checkbox]:disabled+.toggle-visual{opacity:0.38;cursor:not-allowed}
           </button>
         </div>
         <div class="intro-modedesc" id="intro-modedesc"></div>
+        <div class="intro-warning" id="intro-warning" hidden></div>
         <div class="intro-hint"><span id="intro-hint"></span> <a class="intro-settings-link" id="intro-settings-link" role="button" tabindex="0"></a></div>
       </div>
     </div>

--- a/src/core/generation.ts
+++ b/src/core/generation.ts
@@ -47,7 +47,9 @@ export function generateProposal(mode?: string, base?: any): any {
   var s = loadSettings();
   var enabled = getEnabledThemeTypes(s);
   if (enabled.length === 0) enabled = ['People', 'Skill or Trade', 'Trait', 'Personality'];
-  var n = 4;
+  // Teilergebnis: nie mehr verschiedene Themes als aktivierte Theme-Typen (keine
+  // erzwungene Wiederholung auf 4, wenn die Einstellungen zu eng sind).
+  var n = Math.min(4, enabled.length);
   var used: string[] = [];
   var tbs: string[] = [];
   for (var i = 0; i < n; i++) {

--- a/src/i18n/strings.js
+++ b/src/i18n/strings.js
@@ -37,6 +37,7 @@ export const STRINGS={
     settingsLink:'Einstellungen',
     cta:"Los geht's",
     back:'Zurück',
+    partialWarning:function(k){return 'Mit diesen Einstellungen entsteht nur ein Teilergebnis ('+k+' von 4 Themes). Passe die Einstellungen an für einen vollständigen Helden.';},
   },
   swipe:{
     decisionYes:'Passt',decisionNo:'Nicht',

--- a/src/ui/intro.ts
+++ b/src/ui/intro.ts
@@ -3,7 +3,7 @@
 ===================================================== */
 import { $ } from '../util/dom';
 import { PRESETS } from '../core/constants';
-import { loadSettings } from '../core/settings';
+import { loadSettings, getEnabledThemeTypes } from '../core/settings';
 import { setPreset } from './settingsUI';
 import { STRINGS } from '../i18n/strings.js';
 
@@ -27,6 +27,13 @@ export function renderIntro(): void {
     });
   }
   if ($('intro-modedesc')) $('intro-modedesc').textContent = STRINGS.intro.modeDesc[cur];
+  // Teilergebnis-Hinweis: <4 aktivierte Theme-Typen -> kein vollstaendiger Held (4 Themes).
+  var warn = $('intro-warning');
+  if (warn) {
+    var enabledCount = getEnabledThemeTypes(loadSettings()).length;
+    if (enabledCount < 4) { warn.hidden = false; warn.textContent = STRINGS.intro.partialWarning(Math.max(1, enabledCount)); }
+    else { warn.hidden = true; warn.textContent = ''; }
+  }
 }
 export function selectIntroMode(preset: string): void {
   if (PRESETS.indexOf(preset) === -1) return;

--- a/src/ui/swipe.ts
+++ b/src/ui/swipe.ts
@@ -3,9 +3,9 @@
 ===================================================== */
 import { $ } from '../util/dom';
 import { state } from '../state/session';
-import { PHASES } from '../data/inspirations.js';
-import { CFG, tierClass, SCREENS } from '../core/constants';
-import { loadSettings, isThemeTypeEnabled } from '../core/settings';
+import { INSPIRATION_CARDS } from '../data/inspirations.js';
+import { CFG, levelCssClass, SCREENS } from '../core/constants';
+import { loadSettings, isThemeTypeEnabled, effectiveLevel } from '../core/settings';
 import { applyScore, pickBestFrom } from '../core/scoring';
 import { generateProposal, generateHero, composeHeroStory } from '../core/generation';
 import { show, showLoading, hideLoading } from './navigation';
@@ -43,7 +43,13 @@ export function startSwipe(): void {
   state.cardIndex = 0; state.swipes = []; state.affinityScores = {}; state.hookCounts = {};
   state.proposals = []; state.proposalIndex = 0; state.edits = {}; state.hero = null; state.busy = false;
   state.currentCharacterId = null; // neue Sitzung -> neuer Charakter beim Speichern
-  state.shuffledCards = diversifyFirstN(PHASES[0].cards, CFG.MIN_SWIPES_FOR_SKIP);
+  // Deck passend zu den Einstellungen: nur Inspos mit >=1 aktiviertem Theme-Typ.
+  // Inspos ohne aktiven Typ wuerden ins Leere laufen -> raus aus dem Stapel.
+  var _s = loadSettings();
+  var eligible = INSPIRATION_CARDS.filter(function (c: any) {
+    return Object.keys(c.affinities || {}).some(function (t) { return isThemeTypeEnabled(t, _s); });
+  });
+  state.shuffledCards = diversifyFirstN(eligible, CFG.MIN_SWIPES_FOR_SKIP);
 
   var firstBatch = state.shuffledCards.slice(0, IMG_GATE_COUNT)
     .map(function (c: any) { return c.image; }).filter(Boolean);
@@ -105,7 +111,7 @@ export function renderCard(): void {
         .sort(function (a: any, b: any) { return b[1] - a[1]; }).slice(0, 3);
       if (sorted.length > 0) {
         var chips = sorted.map(function (kv: any) {
-          return '<span class="card-theme-tag ' + tierClass(kv[0]) + '">' + escapeHtml(displayThemebook(kv[0])) + '</span>';
+          return '<span class="card-theme-tag ' + levelCssClass(effectiveLevel(kv[0], _settings)) + '">' + escapeHtml(displayThemebook(kv[0])) + '</span>';
         }).join('');
         var label = escapeHtml(STRINGS.swipe.possibleThemesLabel);
         footBand = '<div class="card-foot">' +

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -299,3 +299,37 @@ test('#35: Alle 20 Theme-Types haben Phasenkarten-Affinitaet', async ({ page }) 
   });
   expect(ok).toBe(true);
 });
+
+// PHASE 1.1: Deck passt zu Einstellungen
+test('Deck-Filter: Einsteiger zeigt weniger Karten als Standard (40)', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.setItem('mistheld:settings', JSON.stringify({ preset: 'standard' })));
+  await page.reload();
+  await page.locator('#btn-start').click();
+  await page.locator('#btn-intro-start').click();
+  await expect(page.locator('#card-counter')).toContainText('von 40');
+
+  await page.evaluate(() => localStorage.setItem('mistheld:settings', JSON.stringify({ preset: 'beginner' })));
+  await page.reload();
+  await page.locator('#btn-start').click();
+  await page.locator('#btn-intro-start').click();
+  await expect(page.locator('#card-counter')).toContainText('Karte');
+  const txt = await page.locator('#card-counter').textContent();
+  const total = parseInt((txt.match(/von (\d+)/) || [])[1], 10);
+  expect(total).toBeGreaterThan(0);
+  expect(total).toBeLessThan(40);
+});
+
+test('Enge Einstellungen: Teilergebnis-Warnung im Intro + nur so viele Themes wie aktivierte Typen', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => {
+    const types = ['Circumstance','Devotion','Past','People','Personality','Skill or Trade','Trait','Duty','Influence','Knowledge','Prodigious Ability','Relic','Uncanny Being','Destiny','Dominion','Mastery','Monstrosity','Companion','Magic','Possessions'];
+    const tt = {}; types.forEach(t => { tt[t] = { enabled: t === 'Magic', level: 'Origin' }; });
+    localStorage.setItem('mistheld:settings', JSON.stringify({ preset: 'custom', themeTypes: tt }));
+  });
+  await page.reload();
+  await page.locator('#btn-start').click();
+  await expect(page.locator('#intro-warning')).toBeVisible();
+  const n = await page.evaluate(() => generateProposal('initial').themes.length);
+  expect(n).toBe(1);
+});


### PR DESCRIPTION
Phase 1.1 der Inspirationen-Ueberarbeitung.

## Problem
Der Swipe-Stapel zeigte immer alle 40 Inspos - auch solche, deren Theme-Typen im gewaehlten Spielmodus gar nicht aktiv sind. Man swipte ins Leere.

## Loesung (Hybrid-Ansatz)
- **Eligible-Filter:** Deck nur aus Inspos mit >=1 aktiviertem Affinitaets-Theme-Typ. Ohne aktiven Typ -> raus.
- **Might adaptiv:** Karten-Chips faerben nach effektiver Might-Stufe (`effectiveLevel`) statt statisch `TYPE_TIER`. Reine-Typ-Inspos bleiben nutzbar, Stufe folgt den Einstellungen.
- **Teilergebnis:** `generateProposal` erzeugt nie mehr verschiedene Themes als aktivierte Typen (`n = min(4, enabled)`), statt auf 4 zu wiederholen.
- **Intro-Warnung:** bei <4 aktivierten Typen Hinweis auf Teilergebnis + Empfehlung, die Einstellungen anzupassen.

## Verifiziert (Preview Mobile)
- Einsteiger: 28 Karten, Chips `tc-origin`
- Standard: 40 Karten, gemischte Stufen
- Custom nur Magie: 6 Karten, Warnung sichtbar, 1-Theme-Ergebnis

tsc + Build sauber, 28/28 Playwright (2 neue Tests).
