### PR TITLE
Inspo P1.2: adaptive Laenge, FYP-Adaption, Diversitaet, Held-bereit

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,15 @@ body.overlay-open .mute-btn,body.overlay-open .settings-btn{display:none}
 .btn-ghost:active{transform:scale(0.98)}
 /* SWIPE */
 #screen-swipe{padding:56px 20px 12px;touch-action:none;overflow:hidden;position:relative}
-.card-counter{text-align:center;font-size:0.85rem;color:var(--ink-soft);margin-bottom:10px;letter-spacing:0.06em;flex-shrink:0}
+.card-counter{text-align:center;margin-bottom:10px;flex-shrink:0;min-height:34px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px}
+.readiness-track{width:min(220px,70%);height:5px;border-radius:3px;background:var(--line-soft);overflow:hidden}
+.readiness-fill{height:100%;width:0;border-radius:3px;background:var(--gold);transition:width 0.35s ease,background 0.35s ease}
+.readiness-fill.ready{background:var(--green)}
+.readiness-label{font-size:0.85rem;color:var(--ink-soft);letter-spacing:0.04em}
+.readiness-label[hidden]{display:none}
+.swipe-ready{font-family:var(--sans);font-weight:600;font-size:0.92rem;letter-spacing:0.02em;color:var(--paper);background:var(--green);border:none;border-radius:999px;padding:8px 20px;min-height:38px;cursor:pointer;box-shadow:0 3px 10px rgba(60,40,10,0.18)}
+.swipe-ready:active{transform:scale(0.97)}
+.swipe-ready[hidden]{display:none}
 .card-stage{position:relative;flex:1;min-height:0;margin:0 auto;width:100%;max-width:360px;display:flex;align-items:center;justify-content:center;touch-action:none}
 .card{position:absolute;width:100%;height:100%;background:var(--paper);border:2px solid var(--gold);border-radius:10px;box-shadow:var(--shadow);padding:0;display:flex;flex-direction:column;overflow:hidden;cursor:grab;user-select:none;-webkit-user-select:none;touch-action:none;will-change:transform,opacity;transform:translate3d(0,0,0);transition:transform 0.4s cubic-bezier(0.18,0.89,0.32,1.18),opacity 0.3s ease-out}
 .card.dragging{transition:none;cursor:grabbing}
@@ -415,7 +423,7 @@ input[type=checkbox]:disabled+.toggle-visual{opacity:0.38;cursor:not-allowed}
     <button class="btn btn-primary" id="btn-start"></button>
     <button class="btn btn-ghost" id="btn-library" type="button"></button>
   </div>
-  <div class="app-version">v2026-06-24.1</div>
+  <div class="app-version">v2026-06-24.2</div>
 </section>
 <section id="screen-intro" class="screen">
   <div class="intro-wrap">
@@ -450,13 +458,16 @@ input[type=checkbox]:disabled+.toggle-visual{opacity:0.38;cursor:not-allowed}
   </div>
 </section>
 <section id="screen-swipe" class="screen">
-  <div class="card-counter" id="card-counter"></div>
+  <div class="card-counter" id="card-counter">
+    <div class="readiness-track" aria-hidden="true"><div class="readiness-fill" id="readiness-fill"></div></div>
+    <div class="readiness-label" id="readiness-label"></div>
+    <button class="swipe-ready" id="btn-ready" type="button" hidden></button>
+  </div>
   <div class="card-stage" id="card-stage"></div>
   <div class="swipe-controls">
     <button class="swipe-btn swipe-btn-no" id="btn-no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6L6 18M6 6l12 12"/></svg></button>
     <button class="swipe-btn-undo" id="btn-undo" disabled><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7v6h6"/><path d="M21 17a9 9 0 00-15-6.7L3 13"/></svg></button>
     <button class="swipe-btn swipe-btn-yes" id="btn-yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg></button>
-    <button class="swipe-btn-skip" id="btn-skip" style="display:none"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 4 15 12 5 20 5 4"/><line x1="19" y1="5" x2="19" y2="19"/></svg></button>
   </div>
 </section>
 <section id="screen-result" class="screen">

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -20,6 +20,10 @@ export const CFG = Object.freeze({
   MAX_PROPOSALS: 4, MAX_ELEMENT_ALTS: 3, HAPTIC_MS: 6, AUDIO_VOLUME: 0.4,
   MUTED_KEY: 'mistheld:muted', SETTINGS_KEY: 'mistheld:settings', EXPANDED_PREFERENCE: 0.7,
   MIN_SWIPES_FOR_SKIP: 10,
+  // Inspo P1.2: adaptive Länge / Readiness ("Dein Held ist bereit").
+  MIN_READY_SWIPES: 8,    // Mindestanzahl Swipes, bevor "bereit" gemeldet wird
+  READY_MIN_HOOKS: 3,     // so viele positive Hooks für ein klares Profil
+  ADAPT_HOOK_WEIGHT: 1.5, // Gewicht der Hook-Überlappung in der FYP-Nachsortierung
   // Kern-Qualität R1: Charakter-Profil + Cross-Theme-Kohäsion (Swipe-Schärfung).
   PROFILE_SIZE: 4,        // Top-N positive Hooks bilden das Charakter-Profil
   PROFILE_WEIGHT: 4,      // Gewicht der Profil-Überlappung bei der Auswahl (höher = entschiedener)

--- a/src/core/scoring.ts
+++ b/src/core/scoring.ts
@@ -73,6 +73,24 @@ export function characterProfile(): Record<string, number> {
   return profile;
 }
 export function hasProfileSignal(profile: Record<string, number>): boolean { return Object.keys(profile).length > 0; }
+
+/* =====================================================
+   Inspo P1.2: Readiness — "ist genug Signal da, um einen klaren Helden zu
+   bauen?". Speist die Fortschrittsanzeige + den "Dein Held ist bereit"-Button.
+   ready, wenn genug Swipes + genug verschiedene positive Theme-Typen (>= Anzahl
+   benoetigter Themes) + genug positive Hooks. progress (0..1) fuer den Balken.
+===================================================== */
+export function swipeReadiness(enabledTypes: string[]): { ready: boolean; progress: number } {
+  var maxThemes = Math.min(4, enabledTypes.length || 4);
+  var distinctTypes = enabledTypes.filter(function (t) { return (state.affinityScores[t] || 0) > 0; }).length;
+  var positiveHooks = Object.keys(state.hookCounts).filter(function (h) { return (state.hookCounts[h] || 0) > 0; }).length;
+  var swipes = state.swipes.length;
+  var pSwipes = Math.min(1, swipes / CFG.MIN_READY_SWIPES);
+  var pTypes = maxThemes ? Math.min(1, distinctTypes / maxThemes) : 1;
+  var pHooks = Math.min(1, positiveHooks / CFG.READY_MIN_HOOKS);
+  var ready = swipes >= CFG.MIN_READY_SWIPES && distinctTypes >= maxThemes && positiveHooks >= CFG.READY_MIN_HOOKS;
+  return { ready: ready, progress: (pSwipes + pTypes + pHooks) / 3 };
+}
 export function profileScore(e: any, profile: Record<string, number>): number {
   var hs = tagHooks(e), sc = 0;
   for (var i = 0; i < hs.length; i++) { sc += profile[hs[i]] || 0; }

--- a/src/i18n/strings.js
+++ b/src/i18n/strings.js
@@ -43,6 +43,8 @@ export const STRINGS={
     decisionYes:'Passt',decisionNo:'Nicht',
     cardCounter:function(cur,tot){return 'Karte '+cur+' von '+tot;},
     inspirationLabel:'Inspiration',possibleThemesLabel:'Theme-Typen',examplesLabel:'etwa:',
+    formingLabel:'Dein Held nimmt Form an …',
+    readyCta:'Dein Held ist bereit – ansehen',
     ariaYes:'Passt',ariaNo:'Passt nicht',ariaUndo:'Letzte Karte zurück',ariaSkip:'Restliche Karten überspringen',
   },
   result:{

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,7 +45,7 @@ if ($('intro-settings-link')) {
 $('btn-yes').addEventListener('click', function () { programmaticDecide('yes'); });
 $('btn-no').addEventListener('click', function () { programmaticDecide('no'); });
 $('btn-undo').addEventListener('click', undoLast);
-$('btn-skip').addEventListener('click', skipRemainingSwipes);
+if ($('btn-ready')) $('btn-ready').addEventListener('click', skipRemainingSwipes);
 $('btn-settings').addEventListener('click', openSettings);
 $('btn-settings-back').addEventListener('click', function () {
   saveSettingsFromUI();

--- a/src/ui/swipe.ts
+++ b/src/ui/swipe.ts
@@ -5,8 +5,8 @@ import { $ } from '../util/dom';
 import { state } from '../state/session';
 import { INSPIRATION_CARDS } from '../data/inspirations.js';
 import { CFG, levelCssClass, SCREENS } from '../core/constants';
-import { loadSettings, isThemeTypeEnabled, effectiveLevel } from '../core/settings';
-import { applyScore, pickBestFrom } from '../core/scoring';
+import { loadSettings, isThemeTypeEnabled, effectiveLevel, getEnabledThemeTypes } from '../core/settings';
+import { applyScore, pickBestFrom, swipeReadiness } from '../core/scoring';
 import { generateProposal, generateHero, composeHeroStory } from '../core/generation';
 import { show, showLoading, hideLoading } from './navigation';
 import { setHbEditing, renderHeldenblatt } from './result';
@@ -49,7 +49,8 @@ export function startSwipe(): void {
   var eligible = INSPIRATION_CARDS.filter(function (c: any) {
     return Object.keys(c.affinities || {}).some(function (t) { return isThemeTypeEnabled(t, _s); });
   });
-  state.shuffledCards = diversifyFirstN(eligible, CFG.MIN_SWIPES_FOR_SKIP);
+  // Diversitaet ueber das GESAMTE Deck (nicht nur die ersten N) + voll randomisiert.
+  state.shuffledCards = diversifyFirstN(eligible, eligible.length);
 
   var firstBatch = state.shuffledCards.slice(0, IMG_GATE_COUNT)
     .map(function (c: any) { return c.image; }).filter(Boolean);
@@ -89,13 +90,8 @@ export function renderCard(): void {
   var stage = $('card-stage');
   stage.querySelectorAll('.card:not(.abandoned)').forEach(function (c: any) { c.remove(); });
   if (state.cardIndex >= state.shuffledCards.length) { finishSwiping(); return; }
-  $('card-counter').textContent = STRINGS.swipe.cardCounter(state.cardIndex + 1, state.shuffledCards.length);
+  updateReadiness();
   $('btn-undo').disabled = !canUndo();
-  var skipBtn = $('btn-skip');
-  if (skipBtn) {
-    var done = state.cardIndex;
-    skipBtn.style.display = done >= CFG.MIN_SWIPES_FOR_SKIP ? '' : 'none';
-  }
   for (var i = CFG.STACK_DEPTH - 1; i >= 0; i--) {
     var idx = state.cardIndex + i;
     if (idx >= state.shuffledCards.length) continue;
@@ -176,6 +172,21 @@ export function renderCard(): void {
 
 export function canUndo(): boolean { return state.swipes.length > 0; }
 
+// Inspo P1.2: Fortschritts-/Readiness-Anzeige statt fixem Karten-Zaehler.
+export function updateReadiness(): void {
+  var rd = swipeReadiness(getEnabledThemeTypes(loadSettings()));
+  var fill = $('readiness-fill');
+  if (fill) { fill.style.width = Math.round(rd.progress * 100) + '%'; fill.classList.toggle('ready', rd.ready); }
+  var label = $('readiness-label'), readyBtn = $('btn-ready');
+  if (rd.ready) {
+    if (label) label.hidden = true;
+    if (readyBtn) { readyBtn.hidden = false; readyBtn.textContent = STRINGS.swipe.readyCta; }
+  } else {
+    if (label) { label.hidden = false; label.textContent = STRINGS.swipe.formingLabel; }
+    if (readyBtn) readyBtn.hidden = true;
+  }
+}
+
 export function adaptiveResort(): void {
   if (state.cardIndex < 2 || state.cardIndex >= state.shuffledCards.length) return;
   var pp: any = {};
@@ -185,7 +196,13 @@ export function adaptiveResort(): void {
   if (!Object.keys(pp).length) return;
   var seen = state.shuffledCards.slice(0, state.cardIndex);
   var rem = state.shuffledCards.slice(state.cardIndex);
-  var sc = function (c: any) { return Object.entries(c.affinities || {}).reduce(function (s: number, kv: any) { return s + (pp[kv[0]] || 0) * kv[1]; }, 0); };
+  // FYP-Adaption: verbleibende Karten nach dem bisherigen Verhalten nachsortieren
+  // — Affinitaet (Theme-Typen) UND Hooks (thematisches Profil) gemeinsam.
+  var sc = function (c: any) {
+    var aff = Object.entries(c.affinities || {}).reduce(function (s: number, kv: any) { return s + (pp[kv[0]] || 0) * kv[1]; }, 0);
+    var hk = (c.hooks || []).reduce(function (s: number, h: string) { return s + Math.max(0, state.hookCounts[h] || 0); }, 0);
+    return aff + CFG.ADAPT_HOOK_WEIGHT * hk;
+  };
   rem.sort(function (a: any, b: any) { return sc(b) - sc(a); });
   state.shuffledCards = seen.concat(rem);
 }
@@ -239,9 +256,9 @@ export function undoLast(): void {
   var l = state.swipes.pop(); applyScore(l.card, l.dir, -1); state.cardIndex = Math.max(0, state.cardIndex - 1); renderCard();
 }
 
-// #47: Swipe-Prozess fruehzeitig beenden
+// Inspo P1.2: Swipe-Prozess abschliessen, sobald der Held bereit ist (Button).
 export function skipRemainingSwipes(): void {
-  if (state.cardIndex < CFG.MIN_SWIPES_FOR_SKIP) return;
+  if (!state.swipes.length) return;
   state.cardIndex = state.shuffledCards.length;
   var stage = $('card-stage');
   stage.querySelectorAll('.card:not(.abandoned)').forEach(function (c: any) { c.remove(); });

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -301,23 +301,35 @@ test('#35: Alle 20 Theme-Types haben Phasenkarten-Affinitaet', async ({ page }) 
 });
 
 // PHASE 1.1: Deck passt zu Einstellungen
-test('Deck-Filter: Einsteiger zeigt weniger Karten als Standard (40)', async ({ page }) => {
+test('Deck-Filter: Einsteiger-Stapel kleiner als Standard (40)', async ({ page }) => {
   await page.goto('/');
   await page.evaluate(() => localStorage.setItem('mistheld:settings', JSON.stringify({ preset: 'standard' })));
   await page.reload();
   await page.locator('#btn-start').click();
   await page.locator('#btn-intro-start').click();
-  await expect(page.locator('#card-counter')).toContainText('von 40');
+  const std = await page.evaluate(() => state.shuffledCards.length);
+  expect(std).toBe(40);
 
   await page.evaluate(() => localStorage.setItem('mistheld:settings', JSON.stringify({ preset: 'beginner' })));
   await page.reload();
   await page.locator('#btn-start').click();
   await page.locator('#btn-intro-start').click();
-  await expect(page.locator('#card-counter')).toContainText('Karte');
-  const txt = await page.locator('#card-counter').textContent();
-  const total = parseInt((txt.match(/von (\d+)/) || [])[1], 10);
-  expect(total).toBeGreaterThan(0);
-  expect(total).toBeLessThan(40);
+  const beg = await page.evaluate(() => state.shuffledCards.length);
+  expect(beg).toBeGreaterThan(0);
+  expect(beg).toBeLessThan(40);
+});
+
+// PHASE 1.2: adaptive Länge / Readiness
+test('Readiness: nach genug Ja-Swipes erscheint der Bereit-Button', async ({ page }) => {
+  await page.goto('/');
+  await page.evaluate(() => localStorage.setItem('mistheld:settings', JSON.stringify({ preset: 'standard' })));
+  await page.reload();
+  await page.locator('#btn-start').click();
+  await page.locator('#btn-intro-start').click();
+  await expect(page.locator('.card.front')).toBeVisible();
+  await expect(page.locator('#btn-ready')).toBeHidden();
+  for (let i = 0; i < 12; i++) { await page.locator('#btn-yes').click(); await page.waitForTimeout(70); }
+  await expect(page.locator('#btn-ready')).toBeVisible();
 });
 
 test('Enge Einstellungen: Teilergebnis-Warnung im Intro + nur so viele Themes wie aktivierte Typen', async ({ page }) => {


### PR DESCRIPTION
Phase 1.2 der Inspirationen-Ueberarbeitung.

## Neu
- **Diversitaet ueber das gesamte Deck** (nicht nur die ersten N), je Session voll randomisiert.
- **FYP-Adaption:** verbleibende Karten werden nach Affinitaet UND Hooks (Profil) nachsortiert -> spaetere Inspos passen zunehmend zum bisherigen Swipe-Verhalten.
- **Adaptive Laenge + Readiness:** neuer `swipeReadiness`-Helper (genug Swipes + genug verschiedene positive Theme-Typen + genug positive Hooks). Fixer Karten-Zaehler ersetzt durch Fortschrittsbalken + Label; bei "bereit" erscheint ein **"Dein Held ist bereit"-Button**, der direkt ins Ergebnis springt. Abschluss bleibt Spieler-Entscheidung, Undo bleibt. Alter Skip-nach-10 entfernt.

## Verifiziert
- Preview: nach 8 Ja-Swipes Balken 100% (gruen) + Bereit-Button; Klick -> Ergebnis mit 4 Themes; `swipe-active` sauber entfernt.
- tsc + Build sauber, 29/29 Playwright (2 neue Tests).

Hinweis: rein lokal verifizierbar (kein iOS-Spezifika).
