### PR TITLE
Inspo P2.1: Super-Like (Swipe hoch + Herz-Button)

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,9 +133,10 @@ body.overlay-open .mute-btn,body.overlay-open .settings-btn{display:none}
 .card.front{z-index:20}
 .card.gone-left{transform:translate3d(-130%,30px,0) rotate(-22deg) !important;opacity:0;transition:transform 0.9s cubic-bezier(0.4,0,0.5,1),opacity 0.65s ease-out}
 .card.gone-right{transform:translate3d(130%,30px,0) rotate(22deg) !important;opacity:0;transition:transform 0.9s cubic-bezier(0.4,0,0.5,1),opacity 0.65s ease-out}
+.card.gone-up{transform:translate3d(0,-135%,0) scale(0.9) !important;opacity:0;transition:transform 0.9s cubic-bezier(0.4,0,0.5,1),opacity 0.65s ease-out}
 .card.abandoned{pointer-events:none}
-@keyframes hint-swipe{0%{transform:translate3d(0,0,0)}18%{transform:translate3d(-28px,0,0) rotate(-4deg)}36%{transform:translate3d(0,0,0)}56%{transform:translate3d(32px,0,0) rotate(4deg)}74%,100%{transform:translate3d(0,0,0)}}
-.card-hint{animation:hint-swipe 1.5s ease-in-out 0.9s 1 forwards}
+@keyframes hint-swipe{0%{transform:translate3d(0,0,0)}13%{transform:translate3d(-28px,0,0) rotate(-4deg)}26%{transform:translate3d(0,0,0)}40%{transform:translate3d(32px,0,0) rotate(4deg)}53%{transform:translate3d(0,0,0)}68%{transform:translate3d(0,-34px,0)}82%,100%{transform:translate3d(0,0,0)}}
+.card-hint{animation:hint-swipe 2.1s ease-in-out 0.9s 1 forwards}
 /* Geschmeidiger Übergang: neue Front-Karte + ihr Bild blenden sanft ein
    (nur .front, damit hintere Karten beim Neuaufbau nicht flackern) */
 @keyframes cardIn{from{opacity:0}to{opacity:1}}
@@ -188,6 +189,7 @@ body.overlay-open .mute-btn,body.overlay-open .settings-btn{display:none}
 .card-decision-overlay{position:absolute;top:54px;font-family:var(--serif);font-size:2rem;font-style:italic;font-weight:700;letter-spacing:0.1em;text-transform:uppercase;padding:8px 16px;border:3px solid;border-radius:4px;opacity:0;pointer-events:none;transition:opacity 0.05s linear;z-index:5}
 .card-decision-overlay.yes{right:18px;color:var(--green);border-color:var(--green);transform:rotate(-12deg)}
 .card-decision-overlay.no{left:18px;color:var(--accent);border-color:var(--accent);transform:rotate(12deg)}
+.card-decision-overlay.super{left:50%;top:38%;color:var(--gold);border-color:var(--gold);transform:translate(-50%,-50%) rotate(-6deg);text-align:center}
 .swipe-controls{display:flex;justify-content:center;align-items:center;gap:14px;padding:10px 0 6px;flex-shrink:0}
 .swipe-btn{width:64px;height:64px;border-radius:50%;border:2px solid;background:var(--paper);display:flex;align-items:center;justify-content:center;cursor:pointer;transition:all 0.15s ease;box-shadow:0 2px 8px rgba(60,40,10,0.12)}
 .swipe-btn:active{transform:scale(0.88)}
@@ -195,6 +197,9 @@ body.overlay-open .mute-btn,body.overlay-open .settings-btn{display:none}
 .swipe-btn-no:active{background:var(--accent);color:var(--paper)}
 .swipe-btn-yes{border-color:var(--green);color:var(--green)}
 .swipe-btn-yes:active{background:var(--green);color:var(--paper)}
+.swipe-btn-super{width:52px;height:52px;border-color:var(--gold);color:var(--gold)}
+.swipe-btn-super svg{width:26px;height:26px}
+.swipe-btn-super:active{background:var(--gold);color:var(--paper)}
 .swipe-btn-undo{width:48px;height:48px;border-radius:50%;border:1px solid var(--line);background:rgba(250,243,223,0.9);display:flex;align-items:center;justify-content:center;cursor:pointer;color:var(--ink-soft);transition:all 0.15s ease}
 .swipe-btn-undo:active{transform:scale(0.88)}
 .swipe-btn-undo:disabled{opacity:0.3;cursor:not-allowed}
@@ -423,7 +428,7 @@ input[type=checkbox]:disabled+.toggle-visual{opacity:0.38;cursor:not-allowed}
     <button class="btn btn-primary" id="btn-start"></button>
     <button class="btn btn-ghost" id="btn-library" type="button"></button>
   </div>
-  <div class="app-version">v2026-06-24.3</div>
+  <div class="app-version">v2026-06-27.1</div>
 </section>
 <section id="screen-intro" class="screen">
   <div class="intro-wrap">
@@ -465,8 +470,9 @@ input[type=checkbox]:disabled+.toggle-visual{opacity:0.38;cursor:not-allowed}
   </div>
   <div class="card-stage" id="card-stage"></div>
   <div class="swipe-controls">
-    <button class="swipe-btn swipe-btn-no" id="btn-no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6L6 18M6 6l12 12"/></svg></button>
     <button class="swipe-btn-undo" id="btn-undo" disabled><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7v6h6"/><path d="M21 17a9 9 0 00-15-6.7L3 13"/></svg></button>
+    <button class="swipe-btn swipe-btn-no" id="btn-no"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6L6 18M6 6l12 12"/></svg></button>
+    <button class="swipe-btn swipe-btn-super" id="btn-super"><svg viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M12 21s-7.6-4.9-10-9.2C.6 9 1.7 5.6 4.8 4.8 6.9 4.2 9 5 12 8c3-3 5.1-3.8 7.2-3.2 3.1.8 4.2 4.2 2.8 7C19.6 16.1 12 21 12 21z"/></svg></button>
     <button class="swipe-btn swipe-btn-yes" id="btn-yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg></button>
   </div>
 </section>

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -20,6 +20,11 @@ export const CFG = Object.freeze({
   MAX_PROPOSALS: 4, MAX_ELEMENT_ALTS: 3, HAPTIC_MS: 6, AUDIO_VOLUME: 0.4,
   MUTED_KEY: 'mistheld:muted', SETTINGS_KEY: 'mistheld:settings', EXPANDED_PREFERENCE: 0.7,
   MIN_SWIPES_FOR_SKIP: 10,
+  // Phase 2: Super-Like (Swipe hoch / Herz-Button) + Detail-Flip (Tap).
+  SWIPE_UP_DISTANCE: 90,  // px nach oben für Super-Like-Geste
+  SWIPE_UP_VELOCITY: 0.35, // px/ms Aufwärts-Geschwindigkeit als Auslöser
+  SUPERLIKE_WEIGHT: 2,    // Gewicht eines Super-Likes (Affinitäten + Hooks)
+  TAP_MOVE_MAX: 8,        // max. Bewegung (px), damit ein Pointer-Up als Tap (Flip) zählt
   // Inspo P1.2: adaptive Länge / Readiness ("Dein Held ist bereit").
   MIN_READY_SWIPES: 8,    // Mindestanzahl Swipes, bevor "bereit" gemeldet wird
   READY_MIN_HOOKS: 3,     // so viele positive Hooks für ein klares Profil

--- a/src/core/scoring.ts
+++ b/src/core/scoring.ts
@@ -8,8 +8,10 @@ import { tagText, isExpanded } from '../util/text';
 
 export function tagHooks(e: any): string[] { return (e && typeof e === 'object' && Array.isArray(e.hooks)) ? e.hooks : []; }
 
-export function applyScore(card: any, dir: string, sign: number): void {
-  var f = (dir === 'yes' ? 1 : -0.2) * sign;
+export function applyScore(card: any, dir: string, sign: number, weight?: number): void {
+  // Positive Richtungen: 'yes' und 'super' (Super-Like). 'no' zaehlt negativ.
+  var pos = dir !== 'no';
+  var f = (pos ? 1 : -0.2) * sign * (weight || 1);
   Object.entries(card.affinities || {}).forEach(function (kv: any) { state.affinityScores[kv[0]] = (state.affinityScores[kv[0]] || 0) + f * kv[1]; });
   // Swipe-Bias: Hooks der Karte mitzaehlen (steuert spaeter Tag-/Held-Auswahl)
   (card.hooks || []).forEach(function (h: string) { state.hookCounts[h] = (state.hookCounts[h] || 0) + f; });

--- a/src/i18n/strings.js
+++ b/src/i18n/strings.js
@@ -40,12 +40,12 @@ export const STRINGS={
     partialWarning:function(k){return 'Mit diesen Einstellungen entsteht nur ein Teilergebnis ('+k+' von 4 Themes). Passe die Einstellungen an für einen vollständigen Helden.';},
   },
   swipe:{
-    decisionYes:'Passt',decisionNo:'Nicht',
+    decisionYes:'Passt',decisionNo:'Nicht',decisionSuper:'Genau ich!',
     cardCounter:function(cur,tot){return 'Karte '+cur+' von '+tot;},
     inspirationLabel:'Inspiration',possibleThemesLabel:'Theme-Typen',examplesLabel:'etwa:',
     formingLabel:'Dein Held nimmt Form an …',
     readyCta:'Dein Held ist bereit – ansehen',
-    ariaYes:'Passt',ariaNo:'Passt nicht',ariaUndo:'Letzte Karte zurück',ariaSkip:'Restliche Karten überspringen',
+    ariaYes:'Passt',ariaNo:'Passt nicht',ariaSuper:'Genau mein Held – zählt doppelt',ariaUndo:'Letzte Karte zurück',ariaSkip:'Restliche Karten überspringen',
   },
   result:{
     btnAccept:'Speichern',

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ import { initStrings, show } from './ui/navigation';
 import { initAudio } from './ui/audio';
 import { initWelcomePreview } from './ui/welcomePreview';
 import { renderIntro, selectIntroMode, saveSettingsFromUI } from './ui/intro';
-import { startSwipe, programmaticDecide, undoLast, skipRemainingSwipes } from './ui/swipe';
+import { startSwipe, programmaticDecide, decide, undoLast, skipRemainingSwipes } from './ui/swipe';
 import { renderHeldenblatt, setHbEditing } from './ui/result';
 import { closeEditSheet } from './ui/editSheet';
 import { openSettings, setPreset, applyQuickAction } from './ui/settingsUI';
@@ -44,6 +44,7 @@ if ($('intro-settings-link')) {
 }
 $('btn-yes').addEventListener('click', function () { programmaticDecide('yes'); });
 $('btn-no').addEventListener('click', function () { programmaticDecide('no'); });
+if ($('btn-super')) $('btn-super').addEventListener('click', function () { programmaticDecide('super'); });
 $('btn-undo').addEventListener('click', undoLast);
 if ($('btn-ready')) $('btn-ready').addEventListener('click', skipRemainingSwipes);
 $('btn-settings').addEventListener('click', openSettings);
@@ -81,6 +82,7 @@ document.addEventListener('keydown', function (e: any) {
   if ($('screen-swipe').classList.contains('active')) {
     if (e.key === 'ArrowRight') { e.preventDefault(); programmaticDecide('yes'); }
     else if (e.key === 'ArrowLeft') { e.preventDefault(); programmaticDecide('no'); }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); programmaticDecide('super'); }
     else if (e.key === 'Backspace') { e.preventDefault(); undoLast(); }
   }
   if ($('screen-result').classList.contains('active')) {
@@ -92,5 +94,5 @@ document.addEventListener('keydown', function (e: any) {
 Object.assign(window as any, {
   state, STRINGS, THEMEBOOKS, PHASES, HERO_FIRSTNAMES,
   generateProposal, generateHero, composeHeroStory, show, renderHeldenblatt,
-  characterProfile, hasConflict,
+  characterProfile, hasConflict, programmaticDecide, decide, undoLast,
 });

--- a/src/ui/swipe.ts
+++ b/src/ui/swipe.ts
@@ -126,7 +126,8 @@ export function renderCard(): void {
     }
     var overlays =
       '<div class="card-decision-overlay yes">' + escapeHtml(STRINGS.swipe.decisionYes) + '</div>' +
-      '<div class="card-decision-overlay no">' + escapeHtml(STRINGS.swipe.decisionNo) + '</div>';
+      '<div class="card-decision-overlay no">' + escapeHtml(STRINGS.swipe.decisionNo) + '</div>' +
+      '<div class="card-decision-overlay super">' + escapeHtml(STRINGS.swipe.decisionSuper) + '</div>';
     var textInner =
       '<div class="card-band">' +
         '<span class="card-eyebrow">' + escapeHtml(STRINGS.swipe.inspirationLabel) + '</span>' +
@@ -190,8 +191,10 @@ export function updateReadiness(): void {
 export function adaptiveResort(): void {
   if (state.cardIndex < 2 || state.cardIndex >= state.shuffledCards.length) return;
   var pp: any = {};
-  state.swipes.filter(function (s: any) { return s.dir === 'yes'; }).forEach(function (s: any) {
-    Object.entries(s.card.affinities || {}).forEach(function (kv: any) { pp[kv[0]] = (pp[kv[0]] || 0) + kv[1]; });
+  // Positive Swipes (Ja UND Super-Like) treiben die Nachsortierung; Super zieht mit seinem Gewicht staerker.
+  state.swipes.filter(function (s: any) { return s.dir !== 'no'; }).forEach(function (s: any) {
+    var w = s.weight || 1;
+    Object.entries(s.card.affinities || {}).forEach(function (kv: any) { pp[kv[0]] = (pp[kv[0]] || 0) + kv[1] * w; });
   });
   if (!Object.keys(pp).length) return;
   var seen = state.shuffledCards.slice(0, state.cardIndex);
@@ -208,52 +211,65 @@ export function adaptiveResort(): void {
 }
 
 export function attachSwipe(el: any): void {
-  var startX = 0, dx = 0, dragging = false, lastX = 0, lastTime = 0, velocityX = 0, activePtr: any = null;
-  var yesEl = el.querySelector('.yes'), noEl = el.querySelector('.no');
+  var startX = 0, startY = 0, dx = 0, dy = 0, dragging = false;
+  var lastX = 0, lastY = 0, lastTime = 0, velocityX = 0, velocityY = 0, activePtr: any = null;
+  var yesEl = el.querySelector('.yes'), noEl = el.querySelector('.no'), superEl = el.querySelector('.super');
+  var resetOverlays = function () { yesEl.style.opacity = '0'; noEl.style.opacity = '0'; if (superEl) superEl.style.opacity = '0'; };
   var upd = function () {
-    if (dx > 8) { yesEl.style.opacity = String(Math.min(1, (dx - 8) / 60)); noEl.style.opacity = '0'; }
-    else if (dx < -8) { noEl.style.opacity = String(Math.min(1, (-dx - 8) / 60)); yesEl.style.opacity = '0'; }
-    else { yesEl.style.opacity = '0'; noEl.style.opacity = '0'; }
+    // Vertikal-dominant & aufwaerts => Super-Like-Overlay, sonst Ja/Nein.
+    if (dy < -8 && Math.abs(dy) > Math.abs(dx)) {
+      if (superEl) superEl.style.opacity = String(Math.min(1, (-dy - 8) / 60)); yesEl.style.opacity = '0'; noEl.style.opacity = '0';
+    } else if (dx > 8) { yesEl.style.opacity = String(Math.min(1, (dx - 8) / 60)); noEl.style.opacity = '0'; if (superEl) superEl.style.opacity = '0'; }
+    else if (dx < -8) { noEl.style.opacity = String(Math.min(1, (-dx - 8) / 60)); yesEl.style.opacity = '0'; if (superEl) superEl.style.opacity = '0'; }
+    else resetOverlays();
   };
   el.addEventListener('pointerdown', function (e: any) {
     if (el.classList.contains('abandoned') || activePtr !== null) return;
     el.classList.remove('card-hint'); activePtr = e.pointerId;
     try { el.setPointerCapture(e.pointerId); } catch (_) {}
-    dragging = true; el.classList.add('dragging'); startX = lastX = e.clientX; lastTime = performance.now(); dx = 0; velocityX = 0;
+    dragging = true; el.classList.add('dragging');
+    startX = lastX = e.clientX; startY = lastY = e.clientY; lastTime = performance.now(); dx = 0; dy = 0; velocityX = 0; velocityY = 0;
   });
   el.addEventListener('pointermove', function (e: any) {
     if (!dragging || e.pointerId !== activePtr) return; if (e.cancelable) e.preventDefault();
     var now = performance.now(), dt = now - lastTime;
-    if (dt > 0) velocityX = velocityX * 0.5 + ((e.clientX - lastX) / dt) * 0.5;
-    lastX = e.clientX; lastTime = now; dx = e.clientX - startX;
-    el.style.transform = 'translate3d(' + dx + 'px,0,0) rotate(' + Math.max(-18, Math.min(18, dx * 0.06)) + 'deg)';
+    if (dt > 0) {
+      velocityX = velocityX * 0.5 + ((e.clientX - lastX) / dt) * 0.5;
+      velocityY = velocityY * 0.5 + ((e.clientY - lastY) / dt) * 0.5;
+    }
+    lastX = e.clientX; lastY = e.clientY; lastTime = now; dx = e.clientX - startX; dy = e.clientY - startY;
+    // Nur Aufwaerts-Hub visualisieren (downward bleibt 0), Rotation aus der Horizontalen.
+    el.style.transform = 'translate3d(' + dx + 'px,' + Math.min(0, dy) + 'px,0) rotate(' + Math.max(-18, Math.min(18, dx * 0.06)) + 'deg)';
     upd();
   }, { passive: false });
   var onUp = function (e: any) {
     if (!dragging || e.pointerId !== activePtr) return;
     dragging = false; activePtr = null; el.classList.remove('dragging');
     try { el.releasePointerCapture(e.pointerId); } catch (_) {}
+    var up = (dy < -CFG.SWIPE_UP_DISTANCE || (velocityY < -CFG.SWIPE_UP_VELOCITY && dy < -4)) && Math.abs(dy) > Math.abs(dx);
     var iy = dx > CFG.SWIPE_DISTANCE || (velocityX > CFG.SWIPE_VELOCITY && dx > 4);
     var in_ = dx < -CFG.SWIPE_DISTANCE || (velocityX < -CFG.SWIPE_VELOCITY && dx < -4);
-    if (iy) flyOut(el, 'yes'); else if (in_) flyOut(el, 'no');
-    else { el.style.transform = 'translate3d(0,0,0) rotate(0deg)'; yesEl.style.opacity = '0'; noEl.style.opacity = '0'; }
+    if (up) flyOut(el, 'super'); else if (iy) flyOut(el, 'yes'); else if (in_) flyOut(el, 'no');
+    else { el.style.transform = 'translate3d(0,0,0) rotate(0deg)'; resetOverlays(); }
   };
   el.addEventListener('pointerup', onUp); el.addEventListener('pointercancel', onUp);
 }
 export function flyOut(el: any, dir: string): void {
   if (el.classList.contains('abandoned')) return;
-  el.classList.remove('card-hint'); el.classList.add('abandoned', dir === 'yes' ? 'gone-right' : 'gone-left');
-  try { if (navigator.vibrate) navigator.vibrate(CFG.HAPTIC_MS); } catch (_) {}
+  var goneClass = dir === 'no' ? 'gone-left' : (dir === 'super' ? 'gone-up' : 'gone-right');
+  el.classList.remove('card-hint'); el.classList.add('abandoned', goneClass);
+  try { if (navigator.vibrate) navigator.vibrate(dir === 'super' ? CFG.HAPTIC_MS * 2 : CFG.HAPTIC_MS); } catch (_) {}
   decide(dir); renderCard(); setTimeout(function () { el.remove(); }, CFG.FLY_DURATION_MS + 80);
 }
 export function decide(dir: string): void {
   var c = state.shuffledCards[state.cardIndex]; if (!c) return;
-  applyScore(c, dir, +1); state.swipes.push({ card: c, dir: dir }); state.cardIndex++; adaptiveResort();
+  var weight = dir === 'super' ? CFG.SUPERLIKE_WEIGHT : 1;
+  applyScore(c, dir, +1, weight); state.swipes.push({ card: c, dir: dir, weight: weight }); state.cardIndex++; adaptiveResort();
 }
 export function programmaticDecide(dir: string): void { var el = $('card-stage').querySelector('.card.front:not(.abandoned)'); if (el) flyOut(el, dir); }
 export function undoLast(): void {
   if (!canUndo()) return;
-  var l = state.swipes.pop(); applyScore(l.card, l.dir, -1); state.cardIndex = Math.max(0, state.cardIndex - 1); renderCard();
+  var l = state.swipes.pop(); applyScore(l.card, l.dir, -1, l.weight || 1); state.cardIndex = Math.max(0, state.cardIndex - 1); renderCard();
 }
 
 // Inspo P1.2: Swipe-Prozess abschliessen, sobald der Held bereit ist (Button).

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -345,3 +345,65 @@ test('Enge Einstellungen: Teilergebnis-Warnung im Intro + nur so viele Themes wi
   const n = await page.evaluate(() => generateProposal('initial').themes.length);
   expect(n).toBe(1);
 });
+
+// PHASE 2.1: Super-Like (Swipe hoch / Herz-Button)
+async function startSwiping(page, preset = 'standard') {
+  await page.goto('/');
+  await page.evaluate((p) => localStorage.setItem('mistheld:settings', JSON.stringify({ preset: p })), preset);
+  await page.reload();
+  await page.locator('#btn-start').click();
+  await page.locator('#btn-intro-start').click();
+  await expect(page.locator('.card.front')).toBeVisible();
+}
+
+test('Super-Like: zählt mit doppeltem Gewicht auf Affinitäten + Hooks', async ({ page }) => {
+  await startSwiping(page);
+  const res = await page.evaluate(() => {
+    const card = state.shuffledCards[state.cardIndex];
+    const type = Object.keys(card.affinities)[0];
+    const hook = (card.hooks || [])[0];
+    decide('super');
+    const last = state.swipes[state.swipes.length - 1];
+    return {
+      weight: last.weight, dir: last.dir,
+      aff: state.affinityScores[type], affExpected: card.affinities[type] * 2,
+      hook: hook ? state.hookCounts[hook] : null,
+    };
+  });
+  expect(res.dir).toBe('super');
+  expect(res.weight).toBe(2);
+  expect(res.aff).toBeCloseTo(res.affExpected, 5);
+  if (res.hook !== null) expect(res.hook).toBeCloseTo(2, 5);
+});
+
+test('Super-Like: undoLast macht das doppelte Gewicht exakt rückgängig', async ({ page }) => {
+  await startSwiping(page);
+  const res = await page.evaluate(() => {
+    decide('super');
+    undoLast();
+    const vals = Object.values(state.affinityScores).concat(Object.values(state.hookCounts));
+    return { swipes: state.swipes.length, maxAbs: vals.reduce((m, v) => Math.max(m, Math.abs(v)), 0) };
+  });
+  expect(res.swipes).toBe(0);
+  expect(res.maxAbs).toBeCloseTo(0, 6);
+});
+
+test('Super-Like: Herz-Button und ArrowUp lösen einen Super-Like aus', async ({ page }) => {
+  await startSwiping(page);
+  await page.locator('#btn-super').click();
+  await page.waitForTimeout(120);
+  let last = await page.evaluate(() => state.swipes[state.swipes.length - 1]);
+  expect(last.dir).toBe('super');
+  expect(last.weight).toBe(2);
+  await page.locator('body').press('ArrowUp');
+  await page.waitForTimeout(120);
+  last = await page.evaluate(() => state.swipes[state.swipes.length - 1]);
+  expect(last.dir).toBe('super');
+});
+
+test('Steuerleiste: Reihenfolge ist Zurück · Ablehnen · Herz · Liken', async ({ page }) => {
+  await startSwiping(page);
+  const ids = await page.evaluate(() =>
+    Array.from(document.querySelectorAll('.swipe-controls button')).map((b) => b.id));
+  expect(ids).toEqual(['btn-undo', 'btn-no', 'btn-super', 'btn-yes']);
+});


### PR DESCRIPTION
## Was
Phase 2.1 der Inspirationen-Ueberarbeitung: Super-Like als dritte Wertung.

## Aenderungen
- Super-Like per Swipe-nach-oben-Geste, Herz-Button (Mitte der Steuerleiste) und ArrowUp
- Doppeltes Gewicht (SUPERLIKE_WEIGHT=2) auf Affinitaeten und Hooks
- Steuerleiste neu sortiert: Zurueck, Ablehnen, Herz, Liken
- Start-Hint-Animation um eine Aufwaerts-Phase erweitert (zeigt die Geste ohne Button)
- Gold-Overlay beim Hochziehen, gone-up-Fluganimation
- applyScore mit Gewichts-Parameter; decide/undoLast/adaptiveResort tragen das Gewicht
- Super zaehlt als positives Signal und beschleunigt die Readiness

## Test plan
- [x] tsc --noEmit gruen
- [x] npm test: 33/33 gruen (4 neue Super-Like-Tests)
- [x] Tag-Validierung gruen
- [x] Preview (Mobile): Steuerleiste korrekt, Karte rendert, Super-Overlay vorhanden

Naechster Schritt Phase 2.2: Detail-Flip (Tippen dreht Karte, zeigt narrativen Ich-Text).

Generated with Claude Code
