### PR TITLE
Inspo P2.2: Detail-Flip (Tippen zeigt narrativen Text)

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,6 +169,14 @@ body.overlay-open .mute-btn,body.overlay-open .settings-btn{display:none}
 .card-theme-tag.tc-variable{background:rgba(169,134,70,0.16);color:#8a6a2e;border:1px solid rgba(169,134,70,0.45)}
 /* Inhalts-Wrapper (Overlays bleiben außerhalb; nur dieser wird beim Bild-Upgrade getauscht) */
 .card-content{flex:1;min-height:0;display:flex;flex-direction:column}
+/* Detail-Flip: Tippen dreht die Karte und zeigt den narrativen Text (Rückseite) */
+.card{perspective:1400px}
+.card-flip{position:absolute;inset:0;transform-style:preserve-3d;transition:transform 0.55s cubic-bezier(0.4,0.1,0.2,1)}
+.card.flipped .card-flip{transform:rotateY(180deg)}
+.card-face{position:absolute;inset:0;display:flex;flex-direction:column;overflow:hidden;border-radius:8px;background:var(--paper);backface-visibility:hidden;-webkit-backface-visibility:hidden}
+.card-back{transform:rotateY(180deg)}
+.card-flip-hint{position:absolute;top:9px;right:11px;z-index:4;width:22px;height:22px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-family:var(--serif);font-style:italic;font-size:0.92rem;font-weight:700;color:#fbf3df;background:rgba(40,30,15,0.42);border:1px solid rgba(251,243,223,0.55);pointer-events:none}
+.card-flip-hint-back{font-style:normal;background:rgba(120,96,48,0.22);color:var(--gold);border-color:rgba(169,134,70,0.5)}
 /* Vollbild-Layout: ganzseitige Illustration mit Verlauf-Scrim */
 .card-photo{position:relative;flex:1;min-height:0;overflow:hidden}
 .card-photo img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;display:block;opacity:0;transition:opacity 0.3s ease}
@@ -428,7 +436,7 @@ input[type=checkbox]:disabled+.toggle-visual{opacity:0.38;cursor:not-allowed}
     <button class="btn btn-primary" id="btn-start"></button>
     <button class="btn btn-ghost" id="btn-library" type="button"></button>
   </div>
-  <div class="app-version">v2026-06-27.1</div>
+  <div class="app-version">v2026-06-27.2</div>
 </section>
 <section id="screen-intro" class="screen">
   <div class="intro-wrap">

--- a/src/ui/swipe.ts
+++ b/src/ui/swipe.ts
@@ -152,17 +152,26 @@ export function renderCard(): void {
           scrimThemes +
         '</div>' +
       '</div>';
-    el.innerHTML = overlays + '<div class="card-content">' + (card.image ? photoInner : textInner) + '</div>';
+    // Detail-Flip: Vorderseite = bisheriger Inhalt, Rueckseite = narrativer Ich-Text.
+    // Bei Foto-Karten ist der Text sonst verborgen; der Tap dreht ihn nach vorn.
+    var frontInner = card.image ? photoInner : textInner;
+    var hintFront = '<span class="card-flip-hint" aria-hidden="true">i</span>';
+    var hintBack = '<span class="card-flip-hint card-flip-hint-back" aria-hidden="true">↩</span>';
+    el.innerHTML = overlays +
+      '<div class="card-flip">' +
+        '<div class="card-face card-front">' + hintFront + '<div class="card-content">' + frontInner + '</div></div>' +
+        '<div class="card-face card-back">' + hintBack + '<div class="card-content">' + textInner + '</div></div>' +
+      '</div>';
     if (i === 0) { attachSwipe(el); if (state.cardIndex === 0 && !state.swipes.length) el.classList.add('card-hint'); }
     stage.appendChild(el);
     if (card.image && !photoCached) {
       (function (cardEl, src, fallbackHtml) {
-        var im: any = cardEl.querySelector('.card-photo img');
+        var im: any = cardEl.querySelector('.card-front .card-photo img');
         if (!im) return;
         if (im.complete && im.naturalWidth > 0) { im.classList.add('loaded'); IMG_CACHE[src] = 'ok'; return; }
         im.onload = function () { im.classList.add('loaded'); IMG_CACHE[src] = 'ok'; };
-        im.onerror = function () { IMG_CACHE[src] = 'bad'; var c = cardEl.querySelector('.card-content'); if (c) c.innerHTML = fallbackHtml; };
-      })(el, card.image, textInner);
+        im.onerror = function () { IMG_CACHE[src] = 'bad'; var c = cardEl.querySelector('.card-front .card-content'); if (c) c.innerHTML = fallbackHtml; };
+      })(el, card.image, frontInner);
     }
   }
   for (var p = 0; p < IMG_PRELOAD_AHEAD; p++) {
@@ -211,7 +220,7 @@ export function adaptiveResort(): void {
 }
 
 export function attachSwipe(el: any): void {
-  var startX = 0, startY = 0, dx = 0, dy = 0, dragging = false;
+  var startX = 0, startY = 0, dx = 0, dy = 0, dragging = false, downTime = 0;
   var lastX = 0, lastY = 0, lastTime = 0, velocityX = 0, velocityY = 0, activePtr: any = null;
   var yesEl = el.querySelector('.yes'), noEl = el.querySelector('.no'), superEl = el.querySelector('.super');
   var resetOverlays = function () { yesEl.style.opacity = '0'; noEl.style.opacity = '0'; if (superEl) superEl.style.opacity = '0'; };
@@ -228,7 +237,7 @@ export function attachSwipe(el: any): void {
     el.classList.remove('card-hint'); activePtr = e.pointerId;
     try { el.setPointerCapture(e.pointerId); } catch (_) {}
     dragging = true; el.classList.add('dragging');
-    startX = lastX = e.clientX; startY = lastY = e.clientY; lastTime = performance.now(); dx = 0; dy = 0; velocityX = 0; velocityY = 0;
+    startX = lastX = e.clientX; startY = lastY = e.clientY; lastTime = downTime = performance.now(); dx = 0; dy = 0; velocityX = 0; velocityY = 0;
   });
   el.addEventListener('pointermove', function (e: any) {
     if (!dragging || e.pointerId !== activePtr) return; if (e.cancelable) e.preventDefault();
@@ -238,6 +247,7 @@ export function attachSwipe(el: any): void {
       velocityY = velocityY * 0.5 + ((e.clientY - lastY) / dt) * 0.5;
     }
     lastX = e.clientX; lastY = e.clientY; lastTime = now; dx = e.clientX - startX; dy = e.clientY - startY;
+    if (el.classList.contains('flipped')) return; // Detail-Flip aktiv: Karte nicht bewegen
     // Nur Aufwaerts-Hub visualisieren (downward bleibt 0), Rotation aus der Horizontalen.
     el.style.transform = 'translate3d(' + dx + 'px,' + Math.min(0, dy) + 'px,0) rotate(' + Math.max(-18, Math.min(18, dx * 0.06)) + 'deg)';
     upd();
@@ -246,6 +256,11 @@ export function attachSwipe(el: any): void {
     if (!dragging || e.pointerId !== activePtr) return;
     dragging = false; activePtr = null; el.classList.remove('dragging');
     try { el.releasePointerCapture(e.pointerId); } catch (_) {}
+    // Tap (kaum Bewegung, kurz) => Detail-Flip umschalten, kein Swipe.
+    var isTap = Math.abs(dx) < CFG.TAP_MOVE_MAX && Math.abs(dy) < CFG.TAP_MOVE_MAX && (performance.now() - downTime) < 400;
+    if (isTap) { el.classList.toggle('flipped'); el.style.transform = 'translate3d(0,0,0) rotate(0deg)'; resetOverlays(); return; }
+    // Auf gedrehter Karte keine Swipe-Entscheidung (erst zurueckdrehen).
+    if (el.classList.contains('flipped')) { el.style.transform = 'translate3d(0,0,0) rotate(0deg)'; resetOverlays(); return; }
     var up = (dy < -CFG.SWIPE_UP_DISTANCE || (velocityY < -CFG.SWIPE_UP_VELOCITY && dy < -4)) && Math.abs(dy) > Math.abs(dx);
     var iy = dx > CFG.SWIPE_DISTANCE || (velocityX > CFG.SWIPE_VELOCITY && dx > 4);
     var in_ = dx < -CFG.SWIPE_DISTANCE || (velocityX < -CFG.SWIPE_VELOCITY && dx < -4);

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -74,7 +74,8 @@ test('Swipe-Karte: Titel + Archetypen, Text- oder Bild-Layout', async ({ page })
   await page.goto('/');
   await page.locator('#btn-start').click();
   await page.locator('#btn-intro-start').click();
-  var front = page.locator('.card.front');
+  // Vorderseite der Flip-Karte (Rueckseite traegt den Narrativtext, hier nicht geprueft)
+  var front = page.locator('.card.front .card-front');
   // Invarianten beider Layouts (Text wie Vollbild): Titel + Archetypen-Zeile, kein ❖-Ornament
   await expect(front.locator('.card-title')).toBeVisible();
   await expect(front.locator('.card-archetypes')).toHaveCount(1);
@@ -406,4 +407,38 @@ test('Steuerleiste: Reihenfolge ist Zurück · Ablehnen · Herz · Liken', async
   const ids = await page.evaluate(() =>
     Array.from(document.querySelectorAll('.swipe-controls button')).map((b) => b.id));
   expect(ids).toEqual(['btn-undo', 'btn-no', 'btn-super', 'btn-yes']);
+});
+
+// PHASE 2.2: Detail-Flip (Tippen dreht die Karte)
+test('Detail-Flip: Tippen dreht die Karte und zeigt den narrativen Ich-Text', async ({ page }) => {
+  await startSwiping(page);
+  const card = page.locator('.card.front');
+  await expect(card).not.toHaveClass(/flipped/);
+  await card.click();
+  await expect(card).toHaveClass(/flipped/);
+  const res = await page.evaluate(() => {
+    const c = state.shuffledCards[state.cardIndex];
+    const back = document.querySelector('.card.front .card-back .card-text');
+    return { matches: !!back && back.textContent === c.text, swipes: state.swipes.length };
+  });
+  expect(res.matches).toBe(true);
+  expect(res.swipes).toBe(0);
+});
+
+test('Detail-Flip: zweiter Tap dreht zurück; Drag auf gedrehter Karte löst keinen Swipe aus', async ({ page }) => {
+  await startSwiping(page);
+  const card = page.locator('.card.front');
+  await card.click();
+  await expect(card).toHaveClass(/flipped/);
+  // Drag nach rechts auf der gedrehten Karte => kein Swipe, bleibt gedreht
+  const box = await card.boundingBox();
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width / 2 + 220, box.y + box.height / 2, { steps: 8 });
+  await page.mouse.up();
+  expect(await page.evaluate(() => state.swipes.length)).toBe(0);
+  await expect(card).toHaveClass(/flipped/);
+  // Zweiter Tap dreht zurück
+  await card.click();
+  await expect(card).not.toHaveClass(/flipped/);
 });


### PR DESCRIPTION
## Was
Phase 2.2 der Inspirationen-Ueberarbeitung: Detail-Flip per Tippen.

## Aenderungen
- Tippen auf die Karte dreht sie und zeigt den narrativen Ich-Text der Inspiration
  (bei Foto-Karten sonst verborgen)
- Karte in Flip-Container: Vorderseite = bisheriger Inhalt, Rueckseite = Narrativ
- 3D-Flip per CSS (perspective + rotateY, backface-hidden), 0.55s
- Tap-Erkennung in attachSwipe (kaum Bewegung, kurz); Drag/Swipe bleiben getrennt
- Auf gedrehter Karte ist die Drag-Swipe-Entscheidung gesperrt (erst zurueckdrehen)
- Bild-Fallback zielt jetzt auf die Vorderseite
- dezenter Tap-Hinweis (i-Glyph vorne, Zurueck-Glyph hinten)

## Test plan
- [x] tsc --noEmit gruen
- [x] npm test: 35/35 gruen (2 neue Flip-Tests; Layout-Test auf Vorderseite eingegrenzt)
- [x] Tag-Validierung gruen
- [x] Preview (Mobile): Tap dreht, Rueckseite zeigt Narrativ + Beispiele + Theme-Typen,
      zweiter Tap dreht zurueck, Drag auf gedrehter Karte loest keinen Swipe aus

Schliesst Phase 2 ab (P2.1 Super-Like #100, P2.2 Detail-Flip dieses PR).

Generated with Claude Code
