### PR TITLE
Swipe-Feinschliff: Herz zentriert + Bereit-Leiste unten

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,16 +114,17 @@ body.overlay-open .mute-btn,body.overlay-open .settings-btn{display:none}
 .btn-ghost:hover{background:var(--paper)}
 .btn-ghost:active{transform:scale(0.98)}
 /* SWIPE */
-#screen-swipe{padding:56px 20px 12px;touch-action:none;overflow:hidden;position:relative}
-.card-counter{text-align:center;margin-bottom:10px;flex-shrink:0;min-height:34px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px}
+#screen-swipe{padding:56px 20px max(12px,env(safe-area-inset-bottom,12px));touch-action:none;overflow:hidden;position:relative}
+.card-counter{text-align:center;margin-bottom:10px;flex-shrink:0;min-height:8px;display:flex;flex-direction:column;align-items:center;justify-content:center}
 .readiness-track{width:min(220px,70%);height:5px;border-radius:3px;background:var(--line-soft);overflow:hidden}
 .readiness-fill{height:100%;width:0;border-radius:3px;background:var(--gold);transition:width 0.35s ease,background 0.35s ease}
 .readiness-fill.ready{background:var(--green)}
-.readiness-label{font-size:0.85rem;color:var(--ink-soft);letter-spacing:0.04em}
-.readiness-label[hidden]{display:none}
-.swipe-ready{font-family:var(--sans);font-weight:600;font-size:0.92rem;letter-spacing:0.02em;color:var(--paper);background:var(--green);border:none;border-radius:999px;padding:8px 20px;min-height:38px;cursor:pointer;box-shadow:0 3px 10px rgba(60,40,10,0.18)}
-.swipe-ready:active{transform:scale(0.97)}
-.swipe-ready[hidden]{display:none}
+/* Bereit-Leiste: feste Voll-Breite unter den Ja/Nein-Buttons; immer sichtbar, grau bis bereit */
+.swipe-ready{flex-shrink:0;width:100%;max-width:360px;margin:6px auto 2px;min-height:50px;font-family:var(--sans);font-weight:600;font-size:1rem;letter-spacing:0.02em;border:1px solid var(--line);border-radius:10px;background:rgba(42,36,25,0.06);color:var(--ink-soft);cursor:default;transition:background 0.3s ease,color 0.3s ease,box-shadow 0.3s ease,border-color 0.3s ease}
+.swipe-ready.ready{color:var(--paper);background:var(--green);border-color:transparent;cursor:pointer;box-shadow:0 4px 14px rgba(60,40,10,0.22);animation:readyPulse 1.8s ease-in-out infinite}
+.swipe-ready.ready:active{transform:scale(0.98)}
+@keyframes readyPulse{0%,100%{box-shadow:0 4px 14px rgba(60,40,10,0.22)}50%{box-shadow:0 4px 22px rgba(91,107,58,0.55)}}
+@media(prefers-reduced-motion:reduce){.swipe-ready.ready{animation:none}}
 .card-stage{position:relative;flex:1;min-height:0;margin:0 auto;width:100%;max-width:360px;display:flex;align-items:center;justify-content:center;touch-action:none}
 .card{position:absolute;width:100%;height:100%;background:var(--paper);border:2px solid var(--gold);border-radius:10px;box-shadow:var(--shadow);padding:0;display:flex;flex-direction:column;overflow:hidden;cursor:grab;user-select:none;-webkit-user-select:none;touch-action:none;will-change:transform,opacity;transform:translate3d(0,0,0);transition:transform 0.4s cubic-bezier(0.18,0.89,0.32,1.18),opacity 0.3s ease-out}
 .card.dragging{transition:none;cursor:grabbing}
@@ -199,6 +200,8 @@ body.overlay-open .mute-btn,body.overlay-open .settings-btn{display:none}
 .card-decision-overlay.no{left:18px;color:var(--accent);border-color:var(--accent);transform:rotate(12deg)}
 .card-decision-overlay.super{left:50%;top:38%;color:var(--gold);border-color:var(--gold);transform:translate(-50%,-50%) rotate(-6deg);text-align:center}
 .swipe-controls{display:flex;justify-content:center;align-items:center;gap:14px;padding:10px 0 6px;flex-shrink:0}
+/* Phantom-Spacer rechts spiegelt den Zurueck-Button -> Herz exakt mittig, gleiche Abstaende */
+.swipe-controls::after{content:'';width:48px;height:48px;flex:0 0 auto}
 .swipe-btn{width:64px;height:64px;border-radius:50%;border:2px solid;background:var(--paper);display:flex;align-items:center;justify-content:center;cursor:pointer;transition:all 0.15s ease;box-shadow:0 2px 8px rgba(60,40,10,0.12)}
 .swipe-btn:active{transform:scale(0.88)}
 .swipe-btn-no{border-color:var(--accent);color:var(--accent)}
@@ -436,7 +439,7 @@ input[type=checkbox]:disabled+.toggle-visual{opacity:0.38;cursor:not-allowed}
     <button class="btn btn-primary" id="btn-start"></button>
     <button class="btn btn-ghost" id="btn-library" type="button"></button>
   </div>
-  <div class="app-version">v2026-06-27.2</div>
+  <div class="app-version">v2026-06-28.1</div>
 </section>
 <section id="screen-intro" class="screen">
   <div class="intro-wrap">
@@ -473,8 +476,6 @@ input[type=checkbox]:disabled+.toggle-visual{opacity:0.38;cursor:not-allowed}
 <section id="screen-swipe" class="screen">
   <div class="card-counter" id="card-counter">
     <div class="readiness-track" aria-hidden="true"><div class="readiness-fill" id="readiness-fill"></div></div>
-    <div class="readiness-label" id="readiness-label"></div>
-    <button class="swipe-ready" id="btn-ready" type="button" hidden></button>
   </div>
   <div class="card-stage" id="card-stage"></div>
   <div class="swipe-controls">
@@ -483,6 +484,7 @@ input[type=checkbox]:disabled+.toggle-visual{opacity:0.38;cursor:not-allowed}
     <button class="swipe-btn swipe-btn-super" id="btn-super"><svg viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M12 21s-7.6-4.9-10-9.2C.6 9 1.7 5.6 4.8 4.8 6.9 4.2 9 5 12 8c3-3 5.1-3.8 7.2-3.2 3.1.8 4.2 4.2 2.8 7C19.6 16.1 12 21 12 21z"/></svg></button>
     <button class="swipe-btn swipe-btn-yes" id="btn-yes"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg></button>
   </div>
+  <button class="swipe-ready" id="btn-ready" type="button" disabled></button>
 </section>
 <section id="screen-result" class="screen">
   <div class="hb-scroll" id="hb-scroll"></div>

--- a/src/ui/swipe.ts
+++ b/src/ui/swipe.ts
@@ -187,13 +187,12 @@ export function updateReadiness(): void {
   var rd = swipeReadiness(getEnabledThemeTypes(loadSettings()));
   var fill = $('readiness-fill');
   if (fill) { fill.style.width = Math.round(rd.progress * 100) + '%'; fill.classList.toggle('ready', rd.ready); }
-  var label = $('readiness-label'), readyBtn = $('btn-ready');
-  if (rd.ready) {
-    if (label) label.hidden = true;
-    if (readyBtn) { readyBtn.hidden = false; readyBtn.textContent = STRINGS.swipe.readyCta; }
-  } else {
-    if (label) { label.hidden = false; label.textContent = STRINGS.swipe.formingLabel; }
-    if (readyBtn) readyBtn.hidden = true;
+  // Bereit-Leiste ist dauerhaft sichtbar: grau/disabled bis bereit, dann gruen/aktiv.
+  var readyBtn: any = $('btn-ready');
+  if (readyBtn) {
+    readyBtn.disabled = !rd.ready;
+    readyBtn.classList.toggle('ready', rd.ready);
+    readyBtn.textContent = rd.ready ? STRINGS.swipe.readyCta : STRINGS.swipe.formingLabel;
   }
 }
 

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -321,16 +321,17 @@ test('Deck-Filter: Einsteiger-Stapel kleiner als Standard (40)', async ({ page }
 });
 
 // PHASE 1.2: adaptive Länge / Readiness
-test('Readiness: nach genug Ja-Swipes erscheint der Bereit-Button', async ({ page }) => {
+test('Readiness: Bereit-Leiste ist von Anfang an sichtbar, anfangs disabled, nach genug Ja-Swipes aktiv', async ({ page }) => {
   await page.goto('/');
   await page.evaluate(() => localStorage.setItem('mistheld:settings', JSON.stringify({ preset: 'standard' })));
   await page.reload();
   await page.locator('#btn-start').click();
   await page.locator('#btn-intro-start').click();
   await expect(page.locator('.card.front')).toBeVisible();
-  await expect(page.locator('#btn-ready')).toBeHidden();
-  for (let i = 0; i < 12; i++) { await page.locator('#btn-yes').click(); await page.waitForTimeout(70); }
   await expect(page.locator('#btn-ready')).toBeVisible();
+  await expect(page.locator('#btn-ready')).toBeDisabled();
+  for (let i = 0; i < 12; i++) { await page.locator('#btn-yes').click(); await page.waitForTimeout(70); }
+  await expect(page.locator('#btn-ready')).toBeEnabled();
 });
 
 test('Enge Einstellungen: Teilergebnis-Warnung im Intro + nur so viele Themes wie aktivierte Typen', async ({ page }) => {
@@ -407,6 +408,16 @@ test('Steuerleiste: Reihenfolge ist Zurück · Ablehnen · Herz · Liken', async
   const ids = await page.evaluate(() =>
     Array.from(document.querySelectorAll('.swipe-controls button')).map((b) => b.id));
   expect(ids).toEqual(['btn-undo', 'btn-no', 'btn-super', 'btn-yes']);
+});
+
+test('Steuerleiste: Herz ist exakt zentriert', async ({ page }) => {
+  await startSwiping(page);
+  const res = await page.evaluate(() => {
+    const row = document.querySelector('.swipe-controls').getBoundingClientRect();
+    const heart = document.getElementById('btn-super').getBoundingClientRect();
+    return { rowCenter: row.left + row.width / 2, heartCenter: heart.left + heart.width / 2 };
+  });
+  expect(Math.abs(res.heartCenter - res.rowCenter)).toBeLessThanOrEqual(2);
 });
 
 // PHASE 2.2: Detail-Flip (Tippen dreht die Karte)


### PR DESCRIPTION
## Was
Zwei Swipe-UI-Nachbesserungen aus Saschas Feedback.

## Aenderungen
- **Herz exakt zentriert**: Phantom-Spacer (::after) spiegelt den Zurueck-Button,
  dadurch ist die Reihe symmetrisch (Zurueck links, Ablehnen/Liken symmetrisch,
  Herz mittig) bei gleichen Abstaenden. CSS-only.
- **Bereit-Button als feste untere Leiste**: wandert unter die Ja/Nein-Reihe,
  ist von Anfang an sichtbar und ausgegraut/disabled, wird beim Bereit-Zustand
  gruen + aktiv (dezenter Puls). Kein Einblenden, kein Layout-Sprung.
- Fortschrittsbalken bleibt oben; Readiness-Label entfernt (Status steht im Button).
- Inspokarten dadurch automatisch etwas niedriger.
- Safe-Area-Abstand unten fuer bessere Erreichbarkeit (Home-Indikator).
- Readiness-Logik unveraendert.

## Test plan
- [x] tsc --noEmit gruen
- [x] npm test: 36/36 gruen (Readiness-Test auf disabled->enabled, neuer Herz-zentriert-Test)
- [x] Preview (Mobile): Herz exakt mittig (Pixel-gleich), graue Leiste sichtbar,
      wird beim Bereit-Zustand gruen/aktiv ohne Sprung, Karten passen

Generated with Claude Code
