### PR TITLE
Fixes: Karten-Flip, Bereit-Button, Ergebnis-Scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,13 +120,13 @@ body.overlay-open .mute-btn,body.overlay-open .settings-btn{display:none}
 .readiness-fill{height:100%;width:0;border-radius:3px;background:var(--gold);transition:width 0.35s ease,background 0.35s ease}
 .readiness-fill.ready{background:var(--green)}
 /* Bereit-Leiste: feste Voll-Breite unter den Ja/Nein-Buttons; immer sichtbar, grau bis bereit */
-.swipe-ready{flex-shrink:0;width:100%;max-width:360px;margin:6px auto 2px;min-height:50px;font-family:var(--sans);font-weight:600;font-size:1rem;letter-spacing:0.02em;border:1px solid var(--line);border-radius:10px;background:rgba(42,36,25,0.06);color:var(--ink-soft);cursor:default;transition:background 0.3s ease,color 0.3s ease,box-shadow 0.3s ease,border-color 0.3s ease}
-.swipe-ready.ready{color:var(--paper);background:var(--green);border-color:transparent;cursor:pointer;box-shadow:0 4px 14px rgba(60,40,10,0.22);animation:readyPulse 1.8s ease-in-out infinite}
-.swipe-ready.ready:active{transform:scale(0.98)}
-@keyframes readyPulse{0%,100%{box-shadow:0 4px 14px rgba(60,40,10,0.22)}50%{box-shadow:0 4px 22px rgba(91,107,58,0.55)}}
+.swipe-ready{flex-shrink:0;width:100%;max-width:360px;margin:6px auto 2px;min-height:52px;font-family:var(--sans);font-weight:700;font-size:1.02rem;letter-spacing:0.02em;border:1px solid var(--line);border-radius:10px;background:#cfc4a8;color:#6b6552;cursor:default;transition:background 0.3s ease,color 0.3s ease,box-shadow 0.3s ease,border-color 0.3s ease}
+.swipe-ready.ready{color:var(--paper);background:var(--green);border-color:transparent;cursor:pointer;box-shadow:0 5px 18px rgba(91,107,58,0.4);animation:readyPulse 1.5s ease-in-out infinite}
+.swipe-ready.ready:active{transform:scale(0.98);animation:none}
+@keyframes readyPulse{0%,100%{transform:scale(1);box-shadow:0 5px 16px rgba(91,107,58,0.38)}50%{transform:scale(1.035);box-shadow:0 8px 26px rgba(91,107,58,0.62)}}
 @media(prefers-reduced-motion:reduce){.swipe-ready.ready{animation:none}}
 .card-stage{position:relative;flex:1;min-height:0;margin:0 auto;width:100%;max-width:360px;display:flex;align-items:center;justify-content:center;touch-action:none}
-.card{position:absolute;width:100%;height:100%;background:var(--paper);border:2px solid var(--gold);border-radius:10px;box-shadow:var(--shadow);padding:0;display:flex;flex-direction:column;overflow:hidden;cursor:grab;user-select:none;-webkit-user-select:none;touch-action:none;will-change:transform,opacity;transform:translate3d(0,0,0);transition:transform 0.4s cubic-bezier(0.18,0.89,0.32,1.18),opacity 0.3s ease-out}
+.card{position:absolute;width:100%;height:100%;padding:0;perspective:1400px;cursor:grab;user-select:none;-webkit-user-select:none;touch-action:none;will-change:transform,opacity;transform:translate3d(0,0,0);transition:transform 0.4s cubic-bezier(0.18,0.89,0.32,1.18),opacity 0.3s ease-out}
 .card.dragging{transition:none;cursor:grabbing}
 .card.behind{pointer-events:none}
 .card.behind-1{transform:translate3d(0,10px,0) scale(0.96);opacity:0.95}
@@ -170,14 +170,14 @@ body.overlay-open .mute-btn,body.overlay-open .settings-btn{display:none}
 .card-theme-tag.tc-variable{background:rgba(169,134,70,0.16);color:#8a6a2e;border:1px solid rgba(169,134,70,0.45)}
 /* Inhalts-Wrapper (Overlays bleiben außerhalb; nur dieser wird beim Bild-Upgrade getauscht) */
 .card-content{flex:1;min-height:0;display:flex;flex-direction:column}
-/* Detail-Flip: Tippen dreht die Karte und zeigt den narrativen Text (Rückseite) */
-.card{perspective:1400px}
-.card-flip{position:absolute;inset:0;transform-style:preserve-3d;transition:transform 0.55s cubic-bezier(0.4,0.1,0.2,1)}
+/* Detail-Flip: Tippen dreht die GANZE Karte; Optik liegt auf den Faces (3D sauber) */
+.card-flip{position:absolute;inset:0;transform-style:preserve-3d;transition:transform 0.5s cubic-bezier(0.2,0.7,0.2,1)}
 .card.flipped .card-flip{transform:rotateY(180deg)}
-.card-face{position:absolute;inset:0;display:flex;flex-direction:column;overflow:hidden;border-radius:8px;background:var(--paper);backface-visibility:hidden;-webkit-backface-visibility:hidden}
+.card-face{position:absolute;inset:0;display:flex;flex-direction:column;overflow:hidden;border:2px solid var(--gold);border-radius:10px;background:var(--paper);box-shadow:var(--shadow);backface-visibility:hidden;-webkit-backface-visibility:hidden}
 .card-back{transform:rotateY(180deg)}
-.card-flip-hint{position:absolute;top:9px;right:11px;z-index:4;width:22px;height:22px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-family:var(--serif);font-style:italic;font-size:0.92rem;font-weight:700;color:#fbf3df;background:rgba(40,30,15,0.42);border:1px solid rgba(251,243,223,0.55);pointer-events:none}
-.card-flip-hint-back{font-style:normal;background:rgba(120,96,48,0.22);color:var(--gold);border-color:rgba(169,134,70,0.5)}
+.card-flip-hint{position:absolute;top:10px;right:12px;z-index:4;width:26px;height:26px;border-radius:50%;display:flex;align-items:center;justify-content:center;color:#fbf3df;background:rgba(40,30,15,0.42);border:1px solid rgba(251,243,223,0.55);pointer-events:none}
+.card-flip-hint svg{width:15px;height:15px}
+.card-flip-hint-back{background:rgba(120,96,48,0.28);color:var(--gold);border-color:rgba(169,134,70,0.5)}
 /* Vollbild-Layout: ganzseitige Illustration mit Verlauf-Scrim */
 .card-photo{position:relative;flex:1;min-height:0;overflow:hidden}
 .card-photo img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;display:block;opacity:0;transition:opacity 0.3s ease}
@@ -439,7 +439,7 @@ input[type=checkbox]:disabled+.toggle-visual{opacity:0.38;cursor:not-allowed}
     <button class="btn btn-primary" id="btn-start"></button>
     <button class="btn btn-ghost" id="btn-library" type="button"></button>
   </div>
-  <div class="app-version">v2026-06-28.1</div>
+  <div class="app-version">v2026-06-28.2</div>
 </section>
 <section id="screen-intro" class="screen">
   <div class="intro-wrap">

--- a/src/ui/library.ts
+++ b/src/ui/library.ts
@@ -45,7 +45,7 @@ function renderLibrary(): void {
       setHbEditing(false);
       document.body.classList.remove('swipe-active');
       show(SCREENS.RESULT);
-      renderHeldenblatt();
+      renderHeldenblatt(true);
     });
   });
   list.querySelectorAll('.lib-del').forEach(function (b: any) {

--- a/src/ui/result.ts
+++ b/src/ui/result.ts
@@ -66,9 +66,10 @@ function hbPlaceholder(label: string): string {
   '</div>';
 }
 function hbDivider(): string { return '<div class="hb-divider" aria-hidden="true"><span class="hb-divider-mark">❖</span></div>'; }
-export function renderHeldenblatt(): void {
+export function renderHeldenblatt(resetScroll?: boolean): void {
   var scroll = $('hb-scroll'); if (!scroll) return;
-  var st = scroll.scrollTop;
+  // Fresh-Entry (nach Swipe / Bibliothek-Oeffnen) startet oben; In-Place-Re-Renders behalten Position.
+  var st = resetScroll ? 0 : scroll.scrollTop;
   var n = state.proposals[state.proposalIndex].themes.length;
   var inner = hbHeroSection() + hbDivider() + hbStorySection() + hbDivider() + '<div class="hb-seclabel hb-themes-label">' + escapeHtml(STRINGS.result.themesLabel) + '</div>';
   for (var i = 0; i < n; i++) inner += hbThemeSection(i);

--- a/src/ui/swipe.ts
+++ b/src/ui/swipe.ts
@@ -152,15 +152,25 @@ export function renderCard(): void {
           scrimThemes +
         '</div>' +
       '</div>';
-    // Detail-Flip: Vorderseite = bisheriger Inhalt, Rueckseite = narrativer Ich-Text.
-    // Bei Foto-Karten ist der Text sonst verborgen; der Tap dreht ihn nach vorn.
+    // Detail-Flip: Vorderseite = bisheriger Inhalt, Rueckseite = nur Titel + Narrativ
+    // (keine Theme-Chips, keine Beispielhelden). Bei Foto-Karten ist der Text sonst verborgen.
     var frontInner = card.image ? photoInner : textInner;
-    var hintFront = '<span class="card-flip-hint" aria-hidden="true">i</span>';
-    var hintBack = '<span class="card-flip-hint card-flip-hint-back" aria-hidden="true">↩</span>';
+    var backInner =
+      '<div class="card-band"><span class="card-eyebrow">' + escapeHtml(STRINGS.swipe.inspirationLabel) + '</span></div>' +
+      '<div class="card-body">' +
+        '<div class="card-prompt">' +
+          '<div class="card-title">' + escapeHtml(card.title) + '</div>' +
+          '<div class="card-divider" aria-hidden="true"><span class="card-divider-mark">❖</span></div>' +
+          '<div class="card-text">' + escapeHtml(card.text) + '</div>' +
+        '</div>' +
+      '</div>';
+    var flipIcon = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-2.64-6.36"/><path d="M21 3v5h-5"/></svg>';
+    var hint = '<span class="card-flip-hint" aria-hidden="true">' + flipIcon + '</span>';
+    var hintBack = '<span class="card-flip-hint card-flip-hint-back" aria-hidden="true">' + flipIcon + '</span>';
     el.innerHTML = overlays +
       '<div class="card-flip">' +
-        '<div class="card-face card-front">' + hintFront + '<div class="card-content">' + frontInner + '</div></div>' +
-        '<div class="card-face card-back">' + hintBack + '<div class="card-content">' + textInner + '</div></div>' +
+        '<div class="card-face card-front">' + hint + '<div class="card-content">' + frontInner + '</div></div>' +
+        '<div class="card-face card-back">' + hintBack + '<div class="card-content">' + backInner + '</div></div>' +
       '</div>';
     if (i === 0) { attachSwipe(el); if (state.cardIndex === 0 && !state.swipes.length) el.classList.add('card-hint'); }
     stage.appendChild(el);
@@ -303,7 +313,7 @@ export function finishSwiping(): void {
     state.hero = generateHero(); state.hero.story = composeHeroStory(); setHbEditing(false);
     show(SCREENS.RESULT);
     requestAnimationFrame(function () {
-      renderHeldenblatt(); hideLoading(); state.busy = false;
+      renderHeldenblatt(true); hideLoading(); state.busy = false;
     });
   }, CFG.LOADING_DELAY_MS);
 }

--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -436,6 +436,26 @@ test('Detail-Flip: Tippen dreht die Karte und zeigt den narrativen Ich-Text', as
   expect(res.swipes).toBe(0);
 });
 
+test('Detail-Flip: Rückseite zeigt nur Titel + Narrativ (keine Chips/Beispiele)', async ({ page }) => {
+  await startSwiping(page);
+  const card = page.locator('.card.front');
+  await card.click();
+  await expect(card).toHaveClass(/flipped/);
+  const res = await page.evaluate(() => {
+    const back = document.querySelector('.card.front .card-back');
+    return {
+      hasTitle: !!back.querySelector('.card-title'),
+      hasText: !!back.querySelector('.card-text'),
+      chips: back.querySelectorAll('.card-theme-tag').length,
+      archetypes: back.querySelectorAll('.card-archetypes').length,
+    };
+  });
+  expect(res.hasTitle).toBe(true);
+  expect(res.hasText).toBe(true);
+  expect(res.chips).toBe(0);
+  expect(res.archetypes).toBe(0);
+});
+
 test('Detail-Flip: zweiter Tap dreht zurück; Drag auf gedrehter Karte löst keinen Swipe aus', async ({ page }) => {
   await startSwiping(page);
   const card = page.locator('.card.front');


### PR DESCRIPTION
## Was
Drei Fixes zum aktuellen Stand vor dem naechsten Qualitaets-Abschnitt.

## 1) Karten-Flip korrekt
- Die GANZE Karte dreht jetzt (Optik auf die Faces verlagert, .card ist transparente
  3D-Schale) statt nur des Inhalts - kein durchscheinendes/gespiegeltes Vorderseiten-Chaos.
- Rueckseite schlank: nur Titel + Narrativ. Keine Theme-Chips, keine Beispielhelden.
- Kopfleiste: einmal "Inspiration" links, umdrehender Pfeil (SVG) oben rechts (statt i).

## 2) Bereit-Button auffaelliger
- Inaktiv: solide gedaempft sichtbar (nicht mehr fast transparent).
- Aktiv: kraeftig gruen mit deutlicher Scale/Glow-Pulsanimation.

## 3) Ergebnisseite startet oben
- renderHeldenblatt(resetScroll): nach Swipe und beim Oeffnen aus der Bibliothek
  scrollt die Seite an den Anfang; In-Place-Re-Renders (Edit/Reroll) behalten die Position.

## Test plan
- [x] tsc --noEmit gruen
- [x] npm test: 37/37 gruen (neuer Test: Rueckseite ohne Chips/Beispiele)
- [x] Preview (Mobile): ganze Karte dreht sauber, Rueckseite nur Titel+Narrativ,
      Pfeil rechts; Bereit-Button inaktiv klar grau / aktiv gruen+animiert;
      Scroll-Reset per Globals verifiziert (Fresh->0, In-Place->Position erhalten).

Generated with Claude Code
