### PR TITLE
Backoffice mobil/statisch bereitstellen

### DIFF
--- a/backoffice.html
+++ b/backoffice.html
@@ -32,6 +32,9 @@ h1{font-size:1.5rem;font-weight:700}
   color:var(--ink);border-radius:8px;padding:7px 14px;cursor:pointer}
 .nav-btn:disabled{opacity:0.4;cursor:not-allowed}
 .progress{font-size:0.88rem;color:var(--ink-soft)}
+.toolbar{padding-top:0!important;gap:8px}
+.toolbar .nav-btn{font-size:0.85rem;padding:5px 11px}
+.toolbar-note{font-size:0.78rem;color:var(--ink-soft);margin-left:auto}
 select{font-family:var(--serif);font-size:0.9rem;padding:6px 8px;border:1px solid var(--line);
   border-radius:8px;background:var(--paper);color:var(--ink);max-width:280px}
 
@@ -104,6 +107,13 @@ select{font-family:var(--serif);font-size:0.9rem;padding:6px 8px;border:1px soli
   <button class="nav-btn" id="btn-prev">‹ Zurück</button>
   <select id="jump" title="Zu Bündel springen"></select>
   <button class="nav-btn" id="btn-next">Weiter ›</button>
+</div>
+<div class="wrap toolbar">
+  <button class="nav-btn" id="btn-export">⬇ Export</button>
+  <button class="nav-btn" id="btn-copy">⧉ Kopieren</button>
+  <button class="nav-btn" id="btn-import">⬆ Import</button>
+  <input type="file" id="file-import" accept="application/json,.json" hidden />
+  <span class="toolbar-note" id="mode-note"></span>
 </div></div>
 
 <div class="wrap" id="content"></div>

--- a/index.html
+++ b/index.html
@@ -444,7 +444,7 @@ input[type=checkbox]:disabled+.toggle-visual{opacity:0.38;cursor:not-allowed}
     <button class="btn btn-primary" id="btn-start"></button>
     <button class="btn btn-ghost" id="btn-library" type="button"></button>
   </div>
-  <div class="app-version">v2026-06-28.5</div>
+  <div class="app-version">v2026-06-28.6</div>
 </section>
 <section id="screen-intro" class="screen">
   <div class="intro-wrap">

--- a/src/review/main.ts
+++ b/src/review/main.ts
@@ -39,6 +39,10 @@ const notReadyThemes = Object.keys(THEMEBOOKS).filter((name) =>
   !allBundles.some((b) => b.themebook === name && b.ready)).length;
 
 // ---- Feedback-Zustand ----
+const LS_KEY = 'mh_tag_feedback';
+// Lokaler Dev-Server (Vite) hat die /api-Middleware; die deployte Pages-Seite nicht.
+const isLocal = /^(localhost|127\.|0\.0\.0\.0$|\[?::1)/.test(location.hostname);
+let mode: string = 'local'; // 'api' (Dev-Middleware) | 'local' (localStorage)
 let feedback: any = {};
 let current = 0;
 let saveTimer: any = null;
@@ -46,27 +50,71 @@ let saveTimer: any = null;
 const $ = (id: string) => document.getElementById(id) as any;
 const tierClass = (tier: string) => 'tier-' + String(tier).toLowerCase().split(' ')[0];
 
-async function loadFeedback() {
-  try {
-    const r = await fetch('/api/tag-feedback');
-    feedback = await r.json();
-  } catch (_) { feedback = {}; }
+function normalize() {
   if (!feedback || typeof feedback !== 'object') feedback = {};
   if (!Array.isArray(feedback._done)) feedback._done = [];
 }
 
+async function loadFeedback() {
+  if (isLocal) {
+    try {
+      const r = await fetch('/api/tag-feedback');
+      if (r.ok) {
+        const j = await r.json();
+        if (j && typeof j === 'object') { feedback = j; mode = 'api'; normalize(); return; }
+      }
+    } catch (_) { /* keine Middleware -> localStorage */ }
+  }
+  mode = 'local';
+  try { feedback = JSON.parse(localStorage.getItem(LS_KEY) || '{}'); } catch (_) { feedback = {}; }
+  normalize();
+}
+
 function saveFeedback() {
   flashSaving();
+  try { localStorage.setItem(LS_KEY, JSON.stringify(feedback)); } catch (_) {} // immer lokal spiegeln
   clearTimeout(saveTimer);
   saveTimer = setTimeout(() => {
-    fetch('/api/tag-feedback', {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(feedback),
-    }).then(() => flashSaved()).catch(() => {});
+    if (mode === 'api') {
+      fetch('/api/tag-feedback', {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(feedback),
+      }).then(() => flashSaved()).catch(() => flashSaved());
+    } else {
+      flashSaved();
+    }
   }, 350);
 }
 function flashSaving() { const el = $('saved'); el.textContent = 'speichere …'; el.classList.add('show'); }
 function flashSaved() { const el = $('saved'); el.textContent = 'gespeichert ✓'; el.classList.add('show'); setTimeout(() => el.classList.remove('show'), 1200); }
+function toast(msg: string) { const el = $('saved'); el.textContent = msg; el.classList.add('show'); setTimeout(() => el.classList.remove('show'), 1800); }
+
+// ---- Export / Kopieren / Import (damit Feedback von Mobil zurueck zu mir kommt) ----
+function exportJson() {
+  const blob = new Blob([JSON.stringify(feedback, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url; a.download = 'tag-feedback.json';
+  document.body.appendChild(a); a.click(); a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+  toast('exportiert ⬇');
+}
+async function copyJson() {
+  const text = JSON.stringify(feedback, null, 2);
+  try { await navigator.clipboard.writeText(text); toast('JSON kopiert ⧉'); }
+  catch (_) { window.prompt('JSON markieren und kopieren:', text); }
+}
+function importJson(file: File) {
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const j = JSON.parse(String(reader.result));
+      if (j && typeof j === 'object') { feedback = j; normalize(); saveFeedback(); current = firstIncomplete(); render(); toast('importiert ⬆'); }
+      else toast('ungültige Datei');
+    } catch (_) { toast('ungültige Datei'); }
+  };
+  reader.readAsText(file);
+}
 
 function bundleComplete(b: Bundle) { return b.tags.every((t) => feedback[t.id] && feedback[t.id].vote); }
 function isDone(b: Bundle) { return feedback._done.indexOf(b.id) >= 0; }
@@ -225,6 +273,13 @@ function firstIncomplete() {
   $('btn-next').onclick = () => go(current + 1);
   $('btn-done').onclick = finishCurrent;
   $('jump').onchange = (e: any) => go(parseInt(e.target.value, 10) || 0);
+  $('btn-export').onclick = exportJson;
+  $('btn-copy').onclick = copyJson;
+  $('btn-import').onclick = () => $('file-import').click();
+  $('file-import').onchange = (e: any) => { const f = e.target.files && e.target.files[0]; if (f) importJson(f); e.target.value = ''; };
+  $('mode-note').textContent = mode === 'api'
+    ? 'Speichert auf Platte (tools/tag-feedback.json)'
+    : 'Speichert im Browser — zum Zurückgeben: Export / Kopieren';
   current = firstIncomplete();
   render();
 })();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,7 +47,9 @@ function tagFeedbackApi(): Plugin {
 
 // GitHub Pages serviert von / (Projektseite) — relative Asset-Pfade via base './'.
 // Statische Laufzeit-Assets (img/, fonts/, mp3) liegen in public/ und landen 1:1 in dist/.
-// backoffice.html ist NICHT als Build-Input gelistet -> bleibt dev-only, wird nie deployed.
+// backoffice.html wird mitgebaut/deployed (erreichbar unter .../backoffice.html).
+// Auf der statischen Seite gibt es KEINE /api/tag-feedback-Middleware -> die Review-Seite
+// faellt dann automatisch auf localStorage + Export zurueck (siehe src/review/main.ts).
 export default defineConfig({
   base: './',
   plugins: [tagFeedbackApi()],
@@ -56,7 +58,10 @@ export default defineConfig({
     target: 'es2020',
     assetsInlineLimit: 0,
     rollupOptions: {
-      input: join(__dirname, 'index.html'),
+      input: {
+        main: join(__dirname, 'index.html'),
+        backoffice: join(__dirname, 'backoffice.html'),
+      },
     },
   },
 });


### PR DESCRIPTION
Macht das Tag-Review-Backoffice ohne Terminal mobil nutzbar.

- `backoffice.html` wird mitgebaut/deployed (`rollupOptions.input` main+backoffice) -> erreichbar unter `.../backoffice.html`.
- `src/review/main.ts`: Persistenz-Autodetect — lokal (Vite) via `/api/tag-feedback` auf Platte, deployt via localStorage + Export/Kopieren/Import (Feedback-Rueckgabe vom Mobilgeraet).

Verifikation: `tsc` gruen, `npm run build` erzeugt `dist/backoffice.html`, lokal getestet (Render/Vote/Persistenz/Export). Folgt auf #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
