### PR TITLE
Backoffice: Auto-Persistenz via Cloudflare Worker + Passwortschutz

### DIFF
--- a/backoffice.html
+++ b/backoffice.html
@@ -96,9 +96,31 @@ select{font-family:var(--serif);font-size:0.9rem;padding:6px 8px;border:1px soli
 
 .empty{margin-top:40px;text-align:center;color:var(--ink-soft)}
 .done-tick{color:var(--green);font-weight:700;margin-left:6px}
+
+/* Login-Overlay (nur Worker-Modus; per JS eingeblendet) */
+.login{display:none;position:fixed;inset:0;z-index:100;background:var(--bg);
+  background-image:radial-gradient(ellipse at top left,rgba(169,134,70,0.10) 0%,transparent 55%);
+  align-items:center;justify-content:center;padding:24px}
+.login-box{background:var(--paper);border:1px solid var(--line);border-radius:16px;
+  box-shadow:var(--shadow);padding:28px 26px;max-width:360px;width:100%;text-align:center}
+.login-box h2{font-size:1.4rem;font-weight:700;margin-bottom:4px}
+.login-box p{color:var(--ink-soft);font-size:0.92rem;margin-bottom:16px}
+.login-box input{width:100%;font-family:var(--serif);font-size:1.05rem;padding:11px 12px;
+  border:1px solid var(--line);border-radius:10px;background:#fff;color:var(--ink);margin-bottom:12px}
+.login-box button{width:100%;font-family:var(--serif);font-size:1.05rem;font-weight:700;border:none;
+  border-radius:10px;padding:11px;cursor:pointer;background:var(--green);color:#fff}
+.login-msg{min-height:1.2em;margin-top:10px;font-size:0.88rem;color:var(--accent)}
 </style>
 </head>
 <body>
+<div class="login" id="login"><div class="login-box">
+  <h2>Tag-Review</h2>
+  <p>Bitte Passwort eingeben, um fortzufahren.</p>
+  <input type="password" id="login-pw" placeholder="Passwort" autocomplete="current-password" />
+  <button id="login-btn">Anmelden</button>
+  <div class="login-msg" id="login-msg"></div>
+</div></div>
+
 <div class="topbar"><div class="wrap">
   <div class="grow">
     <h1>Tag-Review <span style="font-weight:400;color:var(--ink-soft);font-size:1rem">· Backoffice</span></h1>

--- a/index.html
+++ b/index.html
@@ -444,7 +444,7 @@ input[type=checkbox]:disabled+.toggle-visual{opacity:0.38;cursor:not-allowed}
     <button class="btn btn-primary" id="btn-start"></button>
     <button class="btn btn-ghost" id="btn-library" type="button"></button>
   </div>
-  <div class="app-version">v2026-06-28.6</div>
+  <div class="app-version">v2026-06-29.1</div>
 </section>
 <section id="screen-intro" class="screen">
   <div class="intro-wrap">

--- a/src/review/main.ts
+++ b/src/review/main.ts
@@ -38,11 +38,16 @@ const bundles = allBundles.filter((b) => b.ready);
 const notReadyThemes = Object.keys(THEMEBOOKS).filter((name) =>
   !allBundles.some((b) => b.themebook === name && b.ready)).length;
 
-// ---- Feedback-Zustand ----
+// ---- Feedback-Zustand + Persistenz ----
 const LS_KEY = 'mh_tag_feedback';
+const PW_KEY = 'mh_review_pw';
+// NACH dem Worker-Deploy hier die Cloudflare-Worker-URL eintragen (ohne Slash am Ende).
+// Leer = deployte Seite arbeitet wie bisher (localStorage + Export), kein Login.
+const WORKER_URL = '';
 // Lokaler Dev-Server (Vite) hat die /api-Middleware; die deployte Pages-Seite nicht.
 const isLocal = /^(localhost|127\.|0\.0\.0\.0$|\[?::1)/.test(location.hostname);
-let mode: string = 'local'; // 'api' (Dev-Middleware) | 'local' (localStorage)
+let mode: string = 'local'; // 'api' (Dev-Platte) | 'worker' (Cloudflare+Passwort) | 'local' (nur localStorage)
+let password = '';
 let feedback: any = {};
 let current = 0;
 let saveTimer: any = null;
@@ -54,36 +59,64 @@ function normalize() {
   if (!feedback || typeof feedback !== 'object') feedback = {};
   if (!Array.isArray(feedback._done)) feedback._done = [];
 }
+function hasEntries(o: any) { return !!o && Object.keys(o).some((k) => k !== '_done'); }
+function readLocal(): any { try { return JSON.parse(localStorage.getItem(LS_KEY) || '{}'); } catch (_) { return {}; } }
 
-async function loadFeedback() {
+// Lokaler Modus (Dev oder ohne Worker): /api versuchen, sonst localStorage.
+async function loadLocalOrApi() {
   if (isLocal) {
     try {
       const r = await fetch('/api/tag-feedback');
-      if (r.ok) {
-        const j = await r.json();
-        if (j && typeof j === 'object') { feedback = j; mode = 'api'; normalize(); return; }
-      }
+      if (r.ok) { const j = await r.json(); if (j && typeof j === 'object') { feedback = j; mode = 'api'; normalize(); return; } }
     } catch (_) { /* keine Middleware -> localStorage */ }
   }
   mode = 'local';
-  try { feedback = JSON.parse(localStorage.getItem(LS_KEY) || '{}'); } catch (_) { feedback = {}; }
+  feedback = readLocal();
   normalize();
+}
+
+// Worker-Modus: Feedback vom Worker laden (Quelle der Wahrheit, Geräte-Sync).
+async function workerLoad(pw: string): Promise<boolean> {
+  const r = await fetch(WORKER_URL + '/load', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ password: pw }),
+  });
+  if (r.status === 401) return false;
+  if (!r.ok) throw new Error('load ' + r.status);
+  const j = await r.json();
+  const remote = (j && j.feedback) || {};
+  const local = readLocal();
+  // Remote ist führend; nur wenn remote leer ist, lokalen Stand übernehmen (und gleich hochsyncen).
+  feedback = hasEntries(remote) ? remote : local;
+  normalize();
+  password = pw; mode = 'worker';
+  try { sessionStorage.setItem(PW_KEY, pw); } catch (_) {}
+  if (!hasEntries(remote) && hasEntries(local)) syncNow();
+  return true;
 }
 
 function saveFeedback() {
   flashSaving();
   try { localStorage.setItem(LS_KEY, JSON.stringify(feedback)); } catch (_) {} // immer lokal spiegeln
   clearTimeout(saveTimer);
-  saveTimer = setTimeout(() => {
-    if (mode === 'api') {
-      fetch('/api/tag-feedback', {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(feedback),
-      }).then(() => flashSaved()).catch(() => flashSaved());
-    } else {
-      flashSaved();
-    }
-  }, 350);
+  saveTimer = setTimeout(syncNow, mode === 'worker' ? 2500 : 300);
+}
+function syncNow() {
+  clearTimeout(saveTimer);
+  if (mode === 'api') {
+    fetch('/api/tag-feedback', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(feedback) })
+      .then(() => flashSaved()).catch(() => flashSaved());
+  } else if (mode === 'worker') {
+    fetch(WORKER_URL + '/save', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ password, feedback }) })
+      .then((r) => setSync(r.ok)).catch(() => setSync(false));
+  } else {
+    flashSaved();
+  }
+}
+function setSync(ok: boolean) {
+  const note = $('mode-note');
+  if (ok) { flashSaved(); if (note) note.textContent = 'Automatisch gespeichert (Server)'; }
+  else if (note) note.textContent = '⚠ nicht gespeichert — Verbindung? wird erneut versucht';
 }
 function flashSaving() { const el = $('saved'); el.textContent = 'speichere …'; el.classList.add('show'); }
 function flashSaved() { const el = $('saved'); el.textContent = 'gespeichert ✓'; el.classList.add('show'); setTimeout(() => el.classList.remove('show'), 1200); }
@@ -255,6 +288,7 @@ function finishCurrent() {
   if (!b || !bundleComplete(b)) return;
   if (!isDone(b)) feedback._done.push(b.id);
   saveFeedback();
+  if (mode === 'worker') syncNow(); // beim Abschließen sofort committen (Checkpoint)
   // Naechstes unerledigtes Buendel, sonst einfach das naechste
   let next = -1;
   for (let i = current + 1; i < bundles.length; i++) { if (!isDone(bundles[i])) { next = i; break; } }
@@ -267,8 +301,14 @@ function firstIncomplete() {
   return 0;
 }
 
-(async function init() {
-  await loadFeedback();
+function setModeNote() {
+  const note = $('mode-note'); if (!note) return;
+  note.textContent = mode === 'api' ? 'Speichert auf Platte (tools/tag-feedback.json)'
+    : mode === 'worker' ? 'Automatisch gespeichert (Server)'
+    : 'Speichert im Browser — zum Zurückgeben: Export / Kopieren';
+}
+
+function start() {
   $('btn-prev').onclick = () => go(current - 1);
   $('btn-next').onclick = () => go(current + 1);
   $('btn-done').onclick = finishCurrent;
@@ -277,9 +317,39 @@ function firstIncomplete() {
   $('btn-copy').onclick = copyJson;
   $('btn-import').onclick = () => $('file-import').click();
   $('file-import').onchange = (e: any) => { const f = e.target.files && e.target.files[0]; if (f) importJson(f); e.target.value = ''; };
-  $('mode-note').textContent = mode === 'api'
-    ? 'Speichert auf Platte (tools/tag-feedback.json)'
-    : 'Speichert im Browser — zum Zurückgeben: Export / Kopieren';
+  // Beim Verlassen/Tab-Wechsel offene Änderungen sichern (Worker-Modus).
+  window.addEventListener('pagehide', () => { if (mode === 'worker') syncNow(); });
+  document.addEventListener('visibilitychange', () => { if (document.visibilityState === 'hidden' && mode === 'worker') syncNow(); });
+  setModeNote();
   current = firstIncomplete();
   render();
+}
+
+// ---- Login (nur Worker-Modus) ----
+function setLoginMsg(msg: string) { const el = $('login-msg'); if (el) el.textContent = msg; }
+function showLogin() {
+  const overlay = $('login'); overlay.style.display = 'flex';
+  const attempt = async (pw: string) => {
+    if (!pw) { setLoginMsg('Bitte Passwort eingeben.'); return; }
+    setLoginMsg('prüfe …');
+    try {
+      const ok = await workerLoad(pw);
+      if (ok) { overlay.style.display = 'none'; start(); }
+      else setLoginMsg('Falsches Passwort.');
+    } catch (_) { setLoginMsg('Server nicht erreichbar — später erneut versuchen.'); }
+  };
+  $('login-btn').onclick = () => attempt($('login-pw').value);
+  $('login-pw').onkeydown = (e: any) => { if (e.key === 'Enter') attempt($('login-pw').value); };
+  const saved = (() => { try { return sessionStorage.getItem(PW_KEY) || ''; } catch (_) { return ''; } })();
+  if (saved) attempt(saved); // Auto-Login innerhalb derselben Sitzung
+  else $('login-pw').focus();
+}
+
+(async function init() {
+  if (!isLocal && WORKER_URL) {
+    showLogin();
+  } else {
+    await loadLocalOrApi();
+    start();
+  }
 })();

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,0 +1,50 @@
+# Tag-Feedback-Worker — Einrichtung (einmalig)
+
+Dieser Cloudflare Worker nimmt das Feedback der Review-Seite entgegen, prüft ein
+Passwort und schreibt es in den Branch `tag-feedback` dieses Repos (Datei
+`tools/tag-feedback.json`). GitHub-Token + Passwort liegen **nur** im Worker, nie
+im Seitencode.
+
+Alles unten geht im Browser über die Cloudflare- bzw. GitHub-Oberfläche — **kein
+Terminal nötig**.
+
+## 1. GitHub-Token erstellen (fine-grained, minimal)
+1. GitHub → Settings → Developer settings → **Fine-grained tokens** → *Generate new token*.
+2. **Resource owner:** dein Account. **Repository access:** *Only select repositories* → **mistheld**.
+3. **Permissions → Repository permissions → Contents: Read and write** (sonst nichts).
+4. Ablauf nach Wunsch (z.B. 90 Tage). Token generieren und **kopieren**.
+   - Den Token **nicht** in den Chat posten — gleich nur in Cloudflare einfügen.
+
+## 2. Worker anlegen
+1. Cloudflare-Account erstellen (gratis) → Dashboard → **Workers & Pages** → *Create* → *Create Worker*.
+2. Namen vergeben (z.B. `mistheld-feedback`) → *Deploy* (erst der Vorlage).
+3. *Edit code* → den gesamten Inhalt von `worker/feedback-worker.js` einfügen → *Deploy*.
+4. Die **Worker-URL** notieren (z.B. `https://mistheld-feedback.<dein-name>.workers.dev`).
+
+## 3. Variablen & Secrets setzen
+Im Worker → **Settings → Variables and Secrets**:
+
+| Name | Typ | Wert |
+|---|---|---|
+| `REVIEW_PASSWORD` | Secret (encrypt) | dein gewähltes Passwort |
+| `GITHUB_TOKEN` | Secret (encrypt) | der Token aus Schritt 1 |
+| `GITHUB_REPO` | Text | `schwitzermodus/mistheld` |
+| `BRANCH` | Text | `tag-feedback` |
+| `FILE_PATH` | Text | `tools/tag-feedback.json` |
+| `ALLOW_ORIGIN` | Text | `https://schwitzermodus.github.io` |
+
+Nach dem Setzen erneut **Deploy**.
+
+## 4. Mir die Worker-URL geben
+Schick mir die URL aus Schritt 2.4. Ich trage sie in der Review-Seite ein und
+deploye das Frontend. Danach: Seite öffnen → Passwort eingeben → Feedback wird
+automatisch gespeichert und landet im Branch `tag-feedback`.
+
+## Test
+- `POST <URL>/load` mit `{"password":"falsch"}` → `401`.
+- Mit richtigem Passwort → `{"feedback":{...}}`.
+- Eine Bewertung auf der Seite → nach wenigen Sekunden neuer Commit im Branch `tag-feedback`.
+
+## Sicherheit
+- Token ist auf dieses eine Repo + nur „Contents" beschränkt — er kann nichts anderes.
+- Passwort schützt Lesen und Schreiben. Bei Verdacht: Token in GitHub *Revoke*, Passwort im Worker ändern.

--- a/worker/feedback-worker.js
+++ b/worker/feedback-worker.js
@@ -1,0 +1,112 @@
+/* =====================================================
+   Mistheld — Tag-Feedback-Worker (Cloudflare Worker, gratis).
+   Bruecke zwischen der oeffentlichen Review-Seite (GitHub Pages) und dem Repo:
+   - Validiert ein gemeinsames Passwort (Secret REVIEW_PASSWORD).
+   - /load: liest das aktuelle Feedback aus dem Repo-Branch.
+   - /save: schreibt (committet) das Feedback per GitHub-API in den Repo-Branch.
+   GitHub-Token + Passwort liegen NUR als Worker-Secrets vor, nie im Seitencode.
+
+   Deployment + Secrets: siehe worker/README.md. NICHT Teil des Vite-Builds.
+
+   Erwartete Variablen/Secrets (Cloudflare-Dashboard -> Settings -> Variables):
+     REVIEW_PASSWORD  (Secret)  gemeinsames Passwort
+     GITHUB_TOKEN     (Secret)  fine-grained PAT, nur dieses Repo, Contents R/W
+     GITHUB_REPO      (Var)     z.B. "schwitzermodus/mistheld"
+     BRANCH           (Var)     z.B. "tag-feedback"
+     FILE_PATH        (Var)     z.B. "tools/tag-feedback.json"
+     ALLOW_ORIGIN     (Var)     z.B. "https://schwitzermodus.github.io"  (oder "*")
+===================================================== */
+
+function corsHeaders(env) {
+  return {
+    'Access-Control-Allow-Origin': env.ALLOW_ORIGIN || '*',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Max-Age': '86400',
+  };
+}
+function json(obj, status, headers) {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { 'Content-Type': 'application/json; charset=utf-8', ...headers },
+  });
+}
+// UTF-8-sichere Base64-Kodierung (Umlaute!) — btoa/atob sind nur latin1.
+function toBase64(str) {
+  const bytes = new TextEncoder().encode(str);
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}
+function fromBase64(b64) {
+  const bin = atob((b64 || '').replace(/\n/g, ''));
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return new TextDecoder().decode(bytes);
+}
+
+export default {
+  async fetch(request, env) {
+    const cors = corsHeaders(env);
+    if (request.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
+    if (request.method !== 'POST') return json({ error: 'method not allowed' }, 405, cors);
+
+    let body;
+    try { body = await request.json(); } catch (_) { return json({ error: 'bad json' }, 400, cors); }
+    if (!body || typeof body.password !== 'string' || body.password !== env.REVIEW_PASSWORD) {
+      return json({ error: 'unauthorized' }, 401, cors);
+    }
+
+    const repo = env.GITHUB_REPO;
+    const branch = env.BRANCH || 'tag-feedback';
+    const path = env.FILE_PATH || 'tools/tag-feedback.json';
+    const api = `https://api.github.com/repos/${repo}/contents/${encodeURI(path)}`;
+    const gh = {
+      'Authorization': `Bearer ${env.GITHUB_TOKEN}`,
+      'Accept': 'application/vnd.github+json',
+      'User-Agent': 'mistheld-feedback-worker',
+      'X-GitHub-Api-Version': '2022-11-28',
+    };
+    const url = new URL(request.url);
+
+    // ---- /load ----
+    if (url.pathname.endsWith('/load')) {
+      const r = await fetch(`${api}?ref=${encodeURIComponent(branch)}`, { headers: gh });
+      if (r.status === 404) return json({ feedback: {} }, 200, cors);
+      if (!r.ok) return json({ error: 'github load failed', status: r.status }, 502, cors);
+      const data = await r.json();
+      let parsed = {};
+      try { parsed = JSON.parse(fromBase64(data.content)); } catch (_) {}
+      return json({ feedback: parsed }, 200, cors);
+    }
+
+    // ---- /save ----
+    if (url.pathname.endsWith('/save')) {
+      const feedback = body.feedback;
+      if (!feedback || typeof feedback !== 'object') return json({ error: 'no feedback' }, 400, cors);
+
+      let sha;
+      const cur = await fetch(`${api}?ref=${encodeURIComponent(branch)}`, { headers: gh });
+      if (cur.ok) { try { sha = (await cur.json()).sha; } catch (_) {} }
+
+      const doneCount = Array.isArray(feedback._done) ? feedback._done.length : 0;
+      const put = await fetch(api, {
+        method: 'PUT',
+        headers: { ...gh, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          message: `tag-feedback: ${doneCount} Bündel erledigt`,
+          content: toBase64(JSON.stringify(feedback, null, 2)),
+          branch,
+          ...(sha ? { sha } : {}),
+        }),
+      });
+      if (!put.ok) {
+        const detail = await put.text();
+        return json({ error: 'github save failed', status: put.status, detail }, 502, cors);
+      }
+      return json({ ok: true }, 200, cors);
+    }
+
+    return json({ error: 'not found' }, 404, cors);
+  },
+};


### PR DESCRIPTION
Macht das Tag-Review-Feedback automatisch speicher- und zu-mir-uebertragbar und schuetzt die Seite per Passwort.

- `worker/feedback-worker.js` (+ README): Cloudflare Worker prueft ein gemeinsames Passwort und liest/schreibt das Feedback per GitHub-API in den Branch `tag-feedback`. Token + Passwort liegen nur als Worker-Secrets vor.
- `src/review/main.ts`: neuer Modus `worker` mit Login-Overlay, Geraete-Sync (`/load`) und Auto-Save (`/save`, entprellt + bei „Fertig" + bei pagehide). `WORKER_URL` ist noch leer -> die deployte Seite bleibt vorerst im localStorage-Modus (kein Login), bis der Worker steht.
- `backoffice.html`: Login-Overlay.

Naechster Schritt nach Merge: Sascha richtet den Cloudflare Worker ein (worker/README.md), gibt mir die URL; ich trage `WORKER_URL` ein und deploye.

Verifikation: `tsc` gruen, Build erzeugt `dist/backoffice.html`, Dev-Pfad (api-Modus) lokal getestet — kein Login, Speichern auf Platte funktioniert weiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
